### PR TITLE
FIX: 16 channel bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ v3.0.0 set out to move **all** of the data collection to the electron hub. This 
 
 * Dependent on electron hub for all data streaming activity.
 
-## Beta 2
+## Beta 4
+
+* Closes #203
+
+## Beta 2-3
 
 Required a lot of work on the hub. But none the less, this seems to be working decently.
 

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -1127,7 +1127,7 @@ void introAnimation() {
     textLeading(24);
     fill(31, 69, 110, transparency);
     textAlign(CENTER, CENTER);
-    text("OpenBCI GUI v3.0.0-beta2\nAugust 2017", width/2, height/2 + width/9);
+    text("OpenBCI GUI v3.0.0-beta4\nAugust 2017", width/2, height/2 + width/9);
   }
 
   //exit intro animation at t2


### PR DESCRIPTION
# 3.0.0

v3.0.0 set out to move **all** of the data collection to the electron hub. This means moving serial port parsing as well.

### New Features

* Able to use wifi shield with GUI. Streams in at 1000Hz for Cyton and 1600Hz for Ganglion.

### Breaking Changes

* Dependent on electron hub for all data streaming activity.

## Beta 4

* Closes #203