### PR TITLE
alpha_count and beta_count don't need to be nulled

### DIFF
--- a/OpenBCI_GUI/W_Focus.pde
+++ b/OpenBCI_GUI/W_Focus.pde
@@ -146,7 +146,6 @@ class W_Focus extends Widget {
     }
 
     //alpha_avg = beta_avg = 0;
-    alpha_count = beta_count = 0;
 
   }
 


### PR DESCRIPTION
alpha_count and beta_count are local variables, it does not matter if we set them to zero before returning from function, this is unnecessary