### PR TITLE
FIX: For ganglion ble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.0
 
-Use OpenBCIHub v1.3.7 please.
+Use OpenBCIHub v1.3.8 please.
 
 ### New Features
 
@@ -15,17 +15,23 @@ Use OpenBCIHub v1.3.7 please.
 * Did not write to the SD card #277
 * Add button to accelerometer widget to turn accel mode on if the user was just using digital, analog, or marker mode.
 
-### rc1
+## rc2
 
-Update the hub to 1.3.7 to catch more wifi errors
-Finished the udp/tcp
-Add colors to help widget.
+### Bug Fixes
 
-### Beta 3
+* Added stability for ganglion bluetooth #270
+
+## rc1
+
+* Update the hub to 1.3.7 to catch more wifi errors
+* Finished the udp/tcp
+* Add colors to help widget.
+
+## Beta 3
 
 Finished Analog and Digital read widgets.
 
-### Beta 2
+## Beta 2
 
 Initial release
 

--- a/OpenBCI_GUI/BoardGanglion.pde
+++ b/OpenBCI_GUI/BoardGanglion.pde
@@ -195,7 +195,7 @@ class Ganglion {
     if (isBLE()) {
       setSampleRate((int)fsHzBLE);
       hub.setProtocol(PROTOCOL_BLE);
-      hub.searchDeviceStart();
+      // hub.searchDeviceStart();
     } else if (isWifi()) {
       setSampleRate((int)fsHzWifi);
       hub.setProtocol(PROTOCOL_WIFI);

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1217,7 +1217,7 @@ class ControlPanel {
         if (hub.isPortOpen()) hub.closePort();
         ganglion.setInterface(INTERFACE_HUB_BLE);
       } else {
-        output("Please wait till hub is fully initalized");
+        outputWarn("Please wait till hub is fully initalized");
       }
     }
 

--- a/OpenBCI_GUI/InterfaceHub.pde
+++ b/OpenBCI_GUI/InterfaceHub.pde
@@ -710,9 +710,13 @@ class Hub {
       case RESP_SUCCESS:
         output("Transfer Protocol set to " + list[2]);
         println("Transfer Protocol set to " + list[2]);
+        if (eegDataSource == DATASOURCE_GANGLION && ganglion.isBLE()) {
+          hub.searchDeviceStart();
+          outputInfo("BLE was powered up sucessfully, now searching for BLE devices.");
+        }
         break;
       case RESP_ERROR_PROTOCOL_BLE_START:
-        output("Failed to start Ganglion BLE Driver, please see http://docs.openbci.com/Tutorials/02-Ganglion_Getting%20Started_Guide");
+        outputError("Failed to start Ganglion BLE Driver, please see http://docs.openbci.com/Tutorials/02-Ganglion_Getting%20Started_Guide");
         println("Failed to start Ganglion BLE Driver, please see http://docs.openbci.com/Tutorials/02-Ganglion_Getting%20Started_Guide");
         break;
       default:


### PR DESCRIPTION
# v3.2.0

Use OpenBCIHub v1.3.8 please.

### New Features

* Add the Digital Read widget
* Add the Analog Read widget
* Add the Marker Mode widget
* Add info, warn, success, and error types to output function to alert user in help widget.

### Bug Fixes

* Did not write aux values for Cyton with Daisy #272
* Did not write to the SD card #277
* Add button to accelerometer widget to turn accel mode on if the user was just using digital, analog, or marker mode.

## rc2

### Bug Fixes

* Added stability for ganglion bluetooth #270

## rc1

* Update the hub to 1.3.7 to catch more wifi errors
* Finished the udp/tcp
* Add colors to help widget.

## Beta 3

Finished Analog and Digital read widgets.

## Beta 2

Initial release