### PR TITLE
DOCS: update for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Use OpenBCIHub v1.4.2 please.
 
 * Add support for BLED112
 
+## Beta 4
+
+* There was a problem with the release
+
 ## Beta 3
 
 * Add support for static IP for wifi

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -1231,7 +1231,7 @@ void introAnimation() {
     textLeading(24);
     fill(31, 69, 110, transparency);
     textAlign(CENTER, CENTER);
-    text("OpenBCI GUI v3.3.0-beta3\nApril 2018", width/2, height/2 + width/9);
+    text("OpenBCI GUI v3.3.0-beta4\nApril 2018", width/2, height/2 + width/9);
   }
 
   //exit intro animation at t2


### PR DESCRIPTION
# v3.3.0

Use OpenBCIHub v1.4.2 please.

### New Features

* Add support for BLED112

## Beta 4

* There was a problem with the release

## Beta 3

* Add support for static IP for wifi
* Bump Hub to v1.4.2

## Beta 2

* Fix bug with Hub, bump hub to v1.4.1

## Beta 1

* Initial release