### PR TITLE
Fix Bug: Initial screen resolution too big on some laptops

### DIFF
--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -361,7 +361,15 @@ void setup() {
   println("Welcome to the Processing-based OpenBCI GUI!"); //Welcome line.
   println("For more information about how to work with this code base, please visit: http://docs.openbci.com/OpenBCI%20Software/");
   //open window
-  size(1024, 768, P2D);
+  println("Screen Resolution: " displayWidth + " X " + displayHeight);
+  //Set the GUI size based on screen size, can be expanded later to accomodate high res/dpi screens
+  //If 1366x768, set GUI to 976x549 to fix #378 regarding some laptop resolutions
+  if (displayWidth == 1366 && displayHeight == 768) {
+    size(976, 549, P2D);
+  } else {
+    //default 1024x768 resolution with 2D graphics
+    size(1024, 768, P2D);
+  }
   ourApplet = this;
 
   if(frameRateCounter==0){


### PR DESCRIPTION
Fix bug referenced in #378 

Some laptops use a different aspect ratio instead of 16:9 (aka 1024x768 or 1080p). More expections can be added later to accomodate for high DPI and high resolution screens.