### PR TITLE
Add global function settings() to OpenBCI_GUI.pde

### DIFF
--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -373,19 +373,7 @@ void setup() {
   println("Welcome to the Processing-based OpenBCI GUI!"); //Welcome line.
   println("For more information about how to work with this code base, please visit: http://docs.openbci.com/OpenBCI%20Software/");
   //open window
-<<<<<<< HEAD
   ///////////////moved size()
-=======
-  println("Screen Resolution: " displayWidth + " X " + displayHeight);
-  //Set the GUI size based on screen size, can be expanded later to accomodate high res/dpi screens
-  //If 1366x768, set GUI to 976x549 to fix #378 regarding some laptop resolutions
-  if (displayWidth == 1366 && displayHeight == 768) {
-    size(976, 549, P2D);
-  } else {
-    //default 1024x768 resolution with 2D graphics
-    size(1024, 768, P2D);
-  }
->>>>>>> e2f3dcd6d6acd06382ebbcded7baeb897f834ded
   ourApplet = this;
 
   if(frameRateCounter==0){

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -354,6 +354,18 @@ Boolean loadErrorCytonEvent = false;
 
 int frameRateCounter = 1; //0 = 24, 1 = 30, 2 = 45, 3 = 60
 
+void settings() {
+  println("Screen Resolution: " + displayWidth + " X " + displayHeight);
+  //Set the GUI size based on screen size, can be expanded later to accomodate high res/dpi screens
+  //If 1366x768, set GUI to 976x549 to fix #378 regarding some laptop resolutions
+  if (displayWidth == 1366 && displayHeight == 768) {
+    size(976, 549, P2D);
+  } else {
+    //default 1024x768 resolution with 2D graphics
+    size(1024, 768, P2D);
+  }
+}
+
 void setup() {
   if (!isWindows()) hubStop(); //kill any existing hubs before starting a new one..
   hubInit(); // putting down here gives windows time to close any open apps
@@ -361,7 +373,7 @@ void setup() {
   println("Welcome to the Processing-based OpenBCI GUI!"); //Welcome line.
   println("For more information about how to work with this code base, please visit: http://docs.openbci.com/OpenBCI%20Software/");
   //open window
-  size(1024, 768, P2D);
+  ///////////////moved size()
   ourApplet = this;
 
   if(frameRateCounter==0){

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -373,7 +373,6 @@ void setup() {
   println("Welcome to the Processing-based OpenBCI GUI!"); //Welcome line.
   println("For more information about how to work with this code base, please visit: http://docs.openbci.com/OpenBCI%20Software/");
   //open window
-  ///////////////moved size()
   ourApplet = this;
 
   if(frameRateCounter==0){


### PR DESCRIPTION
Fixes issues where size() was called during setup, producing an error in the console and the GUI would not start. 

**settings()** now appears as the first global function, just before the main setup() function