### PR TITLE
FIX: version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v4.0.2
+
+Use OpenBCIHub v2.0.2 please.
+
+### New Features
+
+* Timestamps in CSV now come from the OpenBCIHub
+* Playback widget with recent file history
+* Update GUI button and version check
+
+### Breaking Changes
+
+* Now sending and receiving from the hub in JSON!
+
 # v4.0.0
 
 Use OpenBCIHub v2.0.0 please.

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
     <key>CFBundleShortVersionString</key>
     <string>3</string>
     <key>CFBundleVersion</key>
-    <string>4.0.0-alpha.2</string>
+    <string>4.0.2</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -352,8 +352,8 @@ Boolean settingsLoadedCheck = false; //Used to determine if settings are done lo
 final int initTimeoutThreshold = 12000; //Timeout threshold in milliseconds
 
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v4.0.0-alpha.2";
-String localGUIVersionDate = "September 2018";
+String localGUIVersionString = "v4.0.2";
+String localGUIVersionDate = "November 2018";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiVersionCheckHasOccured = false;
 


### PR DESCRIPTION
# v4.0.2

Use OpenBCIHub v2.0.2 please.

### New Features

* Timestamps in CSV now come from the OpenBCIHub
* Playback widget with recent file history
* Update GUI button and version check

### Breaking Changes

* Now sending and receiving from the hub in JSON!
