### PR TITLE
FIX: mojave issue and ganglion playback closes #399 and #402

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v4.0.3
+
+Use OpenBCIHub v2.0.3 please.
+
+### Bug Fixes
+
+* Ganglion did not work for Mojave #402
+* Ganglion could not do playback file #399
+
+## Beta 0
+
+* Initial Release
+
 # v4.0.2
 
 Use OpenBCIHub v2.0.2 please.

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
     <key>CFBundleShortVersionString</key>
     <string>3</string>
     <key>CFBundleVersion</key>
-    <string>4.0.2</string>
+    <string>4.0.3</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -249,7 +249,7 @@ boolean isOldData = false;
 //Used for playback file
 int indices = 0;
 //# columns used by a playback file determines number of channels
-final int totalColumns4ChanThresh = 8;
+final int totalColumns4ChanThresh = 10;
 final int totalColumns16ChanThresh = 16;
 
 boolean synthesizeData = false;
@@ -352,7 +352,7 @@ Boolean settingsLoadedCheck = false; //Used to determine if settings are done lo
 final int initTimeoutThreshold = 12000; //Timeout threshold in milliseconds
 
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v4.0.2";
+String localGUIVersionString = "v4.0.3";
 String localGUIVersionDate = "November 2018";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiVersionCheckHasOccured = false;


### PR DESCRIPTION
# v4.0.3

Use OpenBCIHub v2.0.3 please.

### Bug Fixes

* Ganglion did not work for Mojave #402
* Ganglion could not do playback file #399

## Beta 0

* Initial Release