### PR TITLE
FIX: crash when clicking in GUI on launch

### DIFF
--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -532,9 +532,12 @@ void mouseDragged() {
         }
     }
 }
-//swtich yard if a click is detected
+//switch yard if a click is detected
 void mousePressed() {
-
+    // don't allow mouse clicks until setup is complete and the UI is initialized
+    if (!setupComplete) {
+        return;
+    }
     // verbosePrint("OpenBCI_GUI: mousePressed: mouse pressed");
     // println("systemMode" + systemMode);
     // controlPanel.CPmousePressed();
@@ -585,6 +588,10 @@ void mousePressed() {
 }
 
 void mouseReleased() {
+    // don't allow mouse clicks until setup is complete and the UI is initialized
+    if (!setupComplete) {
+        return;
+    }
 
     //some buttons light up only when being actively pressed.  Now that we've
     //released the mouse button, turn off those buttons.


### PR DESCRIPTION
The GUI would crash if you clicked inside the GUI window while it was still grey and loading. This is fallout from #433 

Fixed by ignoring mouse clicks until setup thread is complete.