### PR TITLE
Read-only directory warning

### DIFF
--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -17,6 +17,11 @@
 
 //interpret a keypress...the key pressed comes in as "key"
 void keyPressed() {
+    // don't allow key presses until setup is complete and the UI is initialized
+    if (!setupComplete) {
+        return;
+    }
+    
     //note that the Processing variable "key" is the keypress as an ASCII character
     //note that the Processing variable "keyCode" is the keypress as a JAVA keycode.  This differs from ASCII
     //println("OpenBCI_GUI: keyPressed: key = " + key + ", int(key) = " + int(key) + ", keyCode = " + keyCode);

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -389,6 +389,39 @@ void settings() {
 }
 
 void setup() {
+    //V1 FONTS
+    f1 = createFont("fonts/Raleway-SemiBold.otf", 16);
+    f2 = createFont("fonts/Raleway-Regular.otf", 15);
+    f3 = createFont("fonts/Raleway-SemiBold.otf", 15);
+    f4 = createFont("fonts/Raleway-SemiBold.otf", 64);  // clear bigger fonts for widgets
+
+    h1 = createFont("fonts/Montserrat-Regular.otf", 20);
+    h2 = createFont("fonts/Montserrat-Regular.otf", 18);
+    h3 = createFont("fonts/Montserrat-Regular.otf", 16);
+    h4 = createFont("fonts/Montserrat-Regular.otf", 14);
+    h5 = createFont("fonts/Montserrat-Regular.otf", 12);
+
+    p0 = createFont("fonts/OpenSans-Semibold.ttf", 24);
+    p1 = createFont("fonts/OpenSans-Regular.ttf", 20);
+    p2 = createFont("fonts/OpenSans-Regular.ttf", 18);
+    p3 = createFont("fonts/OpenSans-Regular.ttf", 16);
+    p15 = createFont("fonts/OpenSans-Regular.ttf", 15);
+    p4 = createFont("fonts/OpenSans-Regular.ttf", 14);
+    p13 = createFont("fonts/OpenSans-Regular.ttf", 13);
+    p5 = createFont("fonts/OpenSans-Regular.ttf", 12);
+    p6 = createFont("fonts/OpenSans-Regular.ttf", 10);
+
+    // check if the current directory is writable
+    File dummy = new File(sketchPath());
+    if (!dummy.canWrite()) {
+        showStartupError = true;
+        startupErrorMessage = "OpenBCI GUI was launched from a read-only location.\n\n" +
+            "Please move the application to a different location and re-launch.\n" +
+            "If you just downloaded the GUI, move it out of the disk image or Downloads folder.\n\n" +
+            "If this error persists, contact the OpenBCI team for support.";
+        return; // early exit
+    }
+
     // redirect all output to a custom stream that will intercept all prints
     // write them to file and display them in the GUI's console window
     outputStream = new CustomOutputStream(System.out);
@@ -422,38 +455,6 @@ void setup() {
 }
 
 void delayedSetup() {
-    //V1 FONTS
-    f1 = createFont("fonts/Raleway-SemiBold.otf", 16);
-    f2 = createFont("fonts/Raleway-Regular.otf", 15);
-    f3 = createFont("fonts/Raleway-SemiBold.otf", 15);
-    f4 = createFont("fonts/Raleway-SemiBold.otf", 64);  // clear bigger fonts for widgets
-
-    h1 = createFont("fonts/Montserrat-Regular.otf", 20);
-    h2 = createFont("fonts/Montserrat-Regular.otf", 18);
-    h3 = createFont("fonts/Montserrat-Regular.otf", 16);
-    h4 = createFont("fonts/Montserrat-Regular.otf", 14);
-    h5 = createFont("fonts/Montserrat-Regular.otf", 12);
-
-    p0 = createFont("fonts/OpenSans-Semibold.ttf", 24);
-    p1 = createFont("fonts/OpenSans-Regular.ttf", 20);
-    p2 = createFont("fonts/OpenSans-Regular.ttf", 18);
-    p3 = createFont("fonts/OpenSans-Regular.ttf", 16);
-    p15 = createFont("fonts/OpenSans-Regular.ttf", 15);
-    p4 = createFont("fonts/OpenSans-Regular.ttf", 14);
-    p13 = createFont("fonts/OpenSans-Regular.ttf", 13);
-    p5 = createFont("fonts/OpenSans-Regular.ttf", 12);
-    p6 = createFont("fonts/OpenSans-Regular.ttf", 10);
-
-    // check if the current directory is writable
-    File dummy = new File(sketchPath());
-    if (!dummy.canWrite()) {
-        showStartupError = true;
-        startupErrorMessage = "OpenBCI GUI was launched from a read-only location.\n\n" +
-            "Please move the application to a different location and re-launch.\n" +
-            "If this error persists, contact the OpenBCI team for support.";
-        return; // early exit
-    }
-
     if (!isWindows()) hubStop(); //kill any existing hubs before starting a new one..
     hubInit(); // putting down here gives windows time to close any open apps
 
@@ -1484,7 +1485,7 @@ void introAnimation() {
 
 void drawStartupError() {
     final int w = 600;
-    final int h = 300;
+    final int h = 350;
     final int headerHeight = 75;
     final int padding = 20;
 

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -90,6 +90,8 @@ final int INTERFACE_HUB_BLE = 1; // used only by ganglion
 final int INTERFACE_HUB_WIFI = 2; // used by both cyton and ganglion
 final int INTERFACE_HUB_BLED112 = 3; // used only by ganglion with bled dongle
 
+boolean showStartupError = false;
+String startupErrorMessage = "";
 //here are variables that are used if loading input data from a CSV text file...double slash ("\\") is necessary to make a single slash
 String playbackData_fname = "N/A"; //only used if loading input data from a file
 // String playbackData_fname;  //leave blank to cause an "Open File" dialog box to appear at startup.  USEFUL!
@@ -232,6 +234,7 @@ PFont h3; //medium Montserrat
 PFont h4; //small/medium Montserrat
 PFont h5; //small Montserrat
 
+PFont p0; //large bold Open Sans
 PFont p1; //large Open Sans
 PFont p2; //large/medium Open Sans
 PFont p3; //medium Open Sans
@@ -419,18 +422,6 @@ void setup() {
 }
 
 void delayedSetup() {
-
-    if (!isWindows()) hubStop(); //kill any existing hubs before starting a new one..
-    hubInit(); // putting down here gives windows time to close any open apps
-
-    smooth(); //turn this off if it's too slow
-
-    surface.setResizable(true);  //updated from frame.setResizable in Processing 2
-    widthOfLastScreen = width; //for screen resizing (Thank's Tao)
-    heightOfLastScreen = height;
-
-    setupContainers();
-
     //V1 FONTS
     f1 = createFont("fonts/Raleway-SemiBold.otf", 16);
     f2 = createFont("fonts/Raleway-Regular.otf", 15);
@@ -443,6 +434,7 @@ void delayedSetup() {
     h4 = createFont("fonts/Montserrat-Regular.otf", 14);
     h5 = createFont("fonts/Montserrat-Regular.otf", 12);
 
+    p0 = createFont("fonts/OpenSans-Semibold.ttf", 24);
     p1 = createFont("fonts/OpenSans-Regular.ttf", 20);
     p2 = createFont("fonts/OpenSans-Regular.ttf", 18);
     p3 = createFont("fonts/OpenSans-Regular.ttf", 16);
@@ -451,6 +443,27 @@ void delayedSetup() {
     p13 = createFont("fonts/OpenSans-Regular.ttf", 13);
     p5 = createFont("fonts/OpenSans-Regular.ttf", 12);
     p6 = createFont("fonts/OpenSans-Regular.ttf", 10);
+
+    // check if the current directory is writable
+    File dummy = new File(sketchPath());
+    if (!dummy.canWrite()) {
+        showStartupError = true;
+        startupErrorMessage = "OpenBCI GUI was launched from a read-only location.\n\n" +
+            "Please move the application to a different location and re-launch.\n" +
+            "If this error persists, contact the OpenBCI team for support.";
+        return; // early exit
+    }
+
+    if (!isWindows()) hubStop(); //kill any existing hubs before starting a new one..
+    hubInit(); // putting down here gives windows time to close any open apps
+
+    smooth(); //turn this off if it's too slow
+
+    surface.setResizable(true);  //updated from frame.setResizable in Processing 2
+    widthOfLastScreen = width; //for screen resizing (Thank's Tao)
+    heightOfLastScreen = height;
+
+    setupContainers();
 
     //listen for window resize ... used to adjust elements in application
     frame.addComponentListener(new ComponentAdapter() {
@@ -553,7 +566,10 @@ void udpReceiveHandler(byte[] data, String ip, int portRX) {
 //======================== DRAW LOOP =============================//
 
 synchronized void draw() {
-    if(setupComplete) {
+    if (showStartupError) {
+        drawStartupError();
+    }
+    else if (setupComplete) {
         drawLoop_counter++; //signPost("10");
         systemUpdate(); //signPost("20");
         systemDraw();   //signPost("30");
@@ -1463,6 +1479,31 @@ void introAnimation() {
         systemMode = SYSTEMMODE_PREINIT;
         controlPanel.isOpen = true;
     }
+    popStyle();
+}
+
+void drawStartupError() {
+    final int w = 600;
+    final int h = 300;
+    final int headerHeight = 75;
+    final int padding = 20;
+
+    pushStyle();
+    background(bgColor);
+    stroke(204);
+    fill(238);
+    rect((width - w)/2, (height - h)/2, w, h);
+    noStroke();
+    fill(217, 4, 4);
+    rect((width - w)/2, (height - h)/2, w, headerHeight);
+    textFont(p0, 24);
+    fill(255);
+    textAlign(LEFT, CENTER);
+    text("Error", (width - w)/2 + padding, (height - h)/2, w, headerHeight);
+    textFont(p3, 16);
+    fill(102);
+    textAlign(LEFT, TOP);
+    text(startupErrorMessage, (width - w)/2 + padding, (height - h)/2 + padding + headerHeight, w-padding*2, h-padding*2-headerHeight); 
     popStyle();
 }
 


### PR DESCRIPTION
Warn the user when they run the GUI from a read-only directory. Force the user to re-launch the GUI from a different location.

Note: since we'll be deploying the app in a signed .dmg, this error should not get hit due to app Translocation. However, this error message is still good to have just in case the GUI is launched from a read-only location for any other reason.

![Screen Shot 2019-04-06 at 11 48 19 PM](https://user-images.githubusercontent.com/412426/55679855-41f7b600-58c7-11e9-99bf-a1e352c06785.png)
