### PR TITLE
FIX: crash on launch

### DIFF
--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -16,7 +16,7 @@
 //------------------------------------------------------------------------
 
 //interpret a keypress...the key pressed comes in as "key"
-void keyPressed() {
+synchronized void keyPressed() {
     // don't allow key presses until setup is complete and the UI is initialized
     if (!setupComplete) {
         return;
@@ -441,7 +441,7 @@ void mouseDragged() {
     }
 }
 //switch yard if a click is detected
-void mousePressed() {
+synchronized void mousePressed() {
     // don't allow mouse clicks until setup is complete and the UI is initialized
     if (!setupComplete) {
         return;
@@ -486,7 +486,7 @@ void mousePressed() {
     redrawScreenNow = true;  //command a redraw of the GUI whenever the mouse is pressed
 }
 
-void mouseReleased() {
+synchronized void mouseReleased() {
     // don't allow mouse clicks until setup is complete and the UI is initialized
     if (!setupComplete) {
         return;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -392,13 +392,6 @@ void delayedSetup() {
     //setup topNav
     topNav = new TopNav();
 
-    //from the user's perspective, the program hangs out on the ControlPanel until the user presses "Start System".
-    print("Graphics & GUI Library: ");
-    controlPanel = new ControlPanel(this);
-    //The effect of "Start System" is that initSystem() gets called, which starts up the connection to the OpenBCI
-    //hardware (via the "updateSyncState()" process) as well as initializing the rest of the GUI elements.
-    //Once the hardware is synchronized, the main GUI is drawn and the user switches over to the main GUI.
-
     logo_blue = loadImage("logo_blue.png");
     logo_white = loadImage("logo_white.png");
     cog = loadImage("cog_1024x1024.png");
@@ -428,6 +421,11 @@ void delayedSetup() {
     println("OpenBCI_GUI::Setup: Has RX joined multicast: "+udpRX.isJoined());
 
     synchronized(this) {
+        // Instantiate ControlPanel in the synchronized block.
+        // It's important to avoid instantiating a ControlP5 during a draw() call
+        // Otherwise we get a crash on launch 10% of the time
+        controlPanel = new ControlPanel(this);
+
         setupComplete = true; // signal that the setup thread has finished
     }
 }


### PR DESCRIPTION
The gui was crashing on launch about 1/15 times.

This is fallout from the fix to the gui timing out on launch. I had moved a bunch of the setup() code to a separate thread. As it turns out, ControlP5 does not like being instantiated on a separate thread at the same time as the main gui draw() call is happening. The control panel class instantiates two ControlP5 instances.

Moving the instantiation into the synchronized block will make sure that the control panel instance is not created at the same time as a draw() call is running.