### PR TITLE
Fix crash caused by pushStyle/popStyle in shortenString

### DIFF
--- a/OpenBCI_GUI/Extras.pde
+++ b/OpenBCI_GUI/Extras.pde
@@ -183,7 +183,6 @@ String shortenString(String str, float maxWidth, PFont font) {
         return str;
     }
 
-    pushStyle();
     textFont(font); // set font for accurate sizing
     int firstIndex = 0; // forward iterator
     int lastIndex = str.length()-1; // reverse iterator
@@ -197,7 +196,6 @@ String shortenString(String str, float maxWidth, PFont font) {
         firstIndex ++;
         lastIndex --;
     }
-    popStyle(); // unset font
 
     String s1 = str.substring(0, firstIndex); // firstIndex is excluded here
     String s2 = str.substring(lastIndex + 1, str.length()); // manually exclude lastIndex


### PR DESCRIPTION
On Mac running GUI from Processing:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fff34a67868, pid=23208, tid=0x0000000000011e03
#
# JRE version: Java(TM) SE Runtime Environment (8.0_181-b13) (build 1.8.0_181-b13)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.181-b13 mixed mode bsd-amd64 compressed oops)
# Problematic frame:
# C  [libGL.dylib+0x1868]  glEnable+0xf
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Applications/Processing.app/Contents/Java/hs_err_pid23208.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
Could not run the sketch (Target VM failed to initialize).
Make sure that you haven't set the maximum available memory too high.
For more information, read revisions.txt and Help → Troubleshooting.
Could not run the sketch.
```