### PR TITLE
Fix for wifi UDPx3 ('burst') mode

### DIFF
--- a/OpenBCI_GUI/InterfaceHub.pde
+++ b/OpenBCI_GUI/InterfaceHub.pde
@@ -21,6 +21,7 @@ final static String TCP_JSON_KEY_ACTION = "action";
 final static String TCP_JSON_KEY_ACCEL_DATA_COUNTS = "accelDataCounts";
 final static String TCP_JSON_KEY_AUX_DATA = "auxData";
 final static String TCP_JSON_KEY_BOARD_TYPE = "boardType";
+final static String TCP_JSON_KEY_BURST_MODE = "burst";
 final static String TCP_JSON_KEY_CHANNEL_DATA_COUNTS = "channelDataCounts";
 final static String TCP_JSON_KEY_CHANNEL_NUMBER = "channelNumber";
 final static String TCP_JSON_KEY_CHANNEL_SET_CHANNEL_NUMBER = "channelNumber";
@@ -1074,7 +1075,13 @@ class Hub {
     public void connectWifi(String id) {
         JSONObject json = new JSONObject();
         json.setInt(TCP_JSON_KEY_LATENCY, curLatency);
-        json.setString(TCP_JSON_KEY_PROTOCOL, curInternetProtocol);
+        if (curInternetProtocol == UDP_BURST) {
+            json.setString(TCP_JSON_KEY_PROTOCOL, UDP);
+            json.setBoolean(TCP_JSON_KEY_BURST_MODE, true);
+        } else {
+            json.setString(TCP_JSON_KEY_PROTOCOL, curInternetProtocol);
+            json.setBoolean(TCP_JSON_KEY_BURST_MODE, false);
+        }
         json.setInt(TCP_JSON_KEY_SAMPLE_RATE, requestedSampleRate);
         json.setString(TCP_JSON_KEY_NAME, id);
         json.setString(TCP_JSON_KEY_TYPE, TCP_TYPE_CONNECT);
@@ -1304,7 +1311,7 @@ class CheckHubInit extends TimerTask {
         } catch (IOException e) {
             outputWarn("Unable to establish link with the OpenBCI Hub, trying again...");
         }
-        
+
         hubTimerCounter++;
     }
 }


### PR DESCRIPTION
Starting in hub version 1.3.9, requests for the 'udpBurst' protocol from the
GUI were internally remapped to 'udp' protocol with a separate 'burst' field
set to true.  Starting at hub version 2.0.0, it appears this remapping is no
longer done, and instead the GUI command is sent straight to the wifi support
library, which is not intended to recognize 'udpBurst' as a valid protocol.
This protocol name was being passed straight through to a REST URL on the wifi
shield, which did not recognize it and returned a 404 error.  The hub
responded to this 404 error by assuming the wifi shield firmware was out of
date, throwing a RESP_ERROR_WIFI_NEEDS_UPDATE error.