### PR TITLE
4.1.6-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Use OpenBCIHub v2.0.9 please.
 
 ### Bug Fixes
 * Cyton+WiFi unable to start session #555 #590
+* Networking start/stop stream #593
 
 # v4.1.5
 Use OpenBCIHub v2.0.9 please.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Use OpenBCIHub v2.0.9 please.
 ## Beta 0
 
 ### Bug Fixes
-* Cyton+WiFi unable to start session #555
+* Cyton+WiFi unable to start session #555 #590
 
 # v4.1.5
 Use OpenBCIHub v2.0.9 please.

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
         <key>CFBundleShortVersionString</key>
         <string>4</string>
         <key>CFBundleVersion</key>
-        <string>4.1.5</string>
+        <string>4.1.6-beta.0</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -56,7 +56,7 @@ import com.sun.jna.Pointer;
 //                       Global Variables & Instances
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v4.1.5";
+String localGUIVersionString = "v4.1.6-beta.0";
 String localGUIVersionDate = "September 2019";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiVersionCheckHasOccured = false;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -821,9 +821,9 @@ void initSystem() throws Exception {
     verbosePrint("OpenBCI_GUI: initSystem: -- Init 4 -- " + millis());
     
     if (eegDataSource == DATASOURCE_CYTON) {
-        if (hub.getFirmwareVersion() == null && hub.getProtocol() == PROTOCOL_WIFI) {
+        if (hub.getFirmwareVersion().equals(null) && hub.getProtocol().equals(PROTOCOL_WIFI)) {
             println("Cyton+WiFi: Unable to find board firmware version");
-        } else if (hub.getFirmwareVersion() == "v1.0.0") {
+        } else if (hub.getFirmwareVersion().equals("v1.0.0")) {
             abandonInit = true;
         } else {
             //println("FOUND FIRMWARE FROM HUB == " + hub.getFirmwareVersion());

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -821,7 +821,7 @@ void initSystem() throws Exception {
     verbosePrint("OpenBCI_GUI: initSystem: -- Init 4 -- " + millis());
     
     if (eegDataSource == DATASOURCE_CYTON) {
-        if (hub.getFirmwareVersion().equals(null) && hub.getProtocol().equals(PROTOCOL_WIFI)) {
+        if (hub.getFirmwareVersion() == null && hub.getProtocol().equals(PROTOCOL_WIFI)) {
             println("Cyton+WiFi: Unable to find board firmware version");
         } else if (hub.getFirmwareVersion().equals("v1.0.0")) {
             abandonInit = true;

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -728,6 +728,10 @@ class W_Networking extends Widget {
                     networkActive = false;
                     return;
                 }
+            } else {
+	                turnOffButton();        // Change apppearance of button
+	                stopNetwork();          // Stop streams
+	                output("Network Stream Stopped");
             }
         // or if the networking guide button was pressed...
         } else if (guideButton.isActive && guideButton.isMouseHere()) {


### PR DESCRIPTION
- [x] **Pending update for OpenBCI HUB from 2.0.9 -> 2.1.0**

- [x] https://github.com/OpenBCI/OpenBCI_Hub/pull/100

![Screen Shot 2019-09-19 at 9 07 29 PM](https://user-images.githubusercontent.com/25914123/65294940-679b1380-db25-11e9-86d1-163203afae0f.png)

# v4.1.6
Use OpenBCIHub v2.1.0 please.

## Beta 0

### Bug Fixes
* Cyton+WiFi unable to start session #555 #590
* Networking start/stop stream #593
