### PR TITLE
Made an interface defining functions for impedance settings boards.

### DIFF
--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -23,7 +23,7 @@ static class BoardCytonConstants {
     static final float leadOffDrive_amps = 6.0e-9;  //6 nA, set by its Arduino code
 }
 
-class BoardCyton extends BoardBrainFlow {
+class BoardCyton extends BoardBrainFlow implements ImpedanceSettingsBoard {
     private final char[] deactivateChannelChars = {'1', '2', '3', '4', '5', '6', '7', '8', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i'};
     private final char[] activateChannelChars = {'!', '@', '#', '$', '%', '^', '&', '*', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
     private final char[] channelSelectForSettings = {'1', '2', '3', '4', '5', '6', '7', '8', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
@@ -148,6 +148,7 @@ class BoardCyton extends BoardBrainFlow {
         }
     }
 
+    @Override
     public void setImpedanceSettings(int channel, char pORn, boolean active) {
         char p = '0';
         char n = '0';

--- a/OpenBCI_GUI/BoardGanglion.pde
+++ b/OpenBCI_GUI/BoardGanglion.pde
@@ -55,15 +55,15 @@ class BoardGanglion extends BoardBrainFlow {
         configBoard(str(charsToUse[channelIndex]));
     }
 
-    public void setImpedanceSettings(boolean active) {
-        configBoard(active ? "z" : "Z");
-        isCheckingImpedance = active;
-    }
-
     public void setAccelSettings(boolean active) {
         configBoard(active ? "n" : "N");
     }
 
+    public void setCheckingImpedance(boolean checkImpedance) {
+        configBoard(checkImpedance ? "z" : "Z");
+        isCheckingImpedance = checkImpedance;
+    }
+    
     public boolean isCheckingImpedance() {
         return isCheckingImpedance;
     }

--- a/OpenBCI_GUI/BoardNovaXR.pde
+++ b/OpenBCI_GUI/BoardNovaXR.pde
@@ -2,7 +2,7 @@ import brainflow.*;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-class BoardNovaXR extends BoardBrainFlow {
+class BoardNovaXR extends BoardBrainFlow implements ImpedanceSettingsBoard {
 
     private final char[] deactivateChannelChars = {'1', '2', '3', '4', '5', '6', '7', '8', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i'};
     private final char[] activateChannelChars = {'!', '@', '#', '$', '%', '^', '&', '*', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
@@ -44,6 +44,7 @@ class BoardNovaXR extends BoardBrainFlow {
         return false;
     }
 
+    @Override
     public void setImpedanceSettings(int channel, char pORn, boolean active) {
         char p = '0';
         char n = '0';

--- a/OpenBCI_GUI/HardwareSettingsController.pde
+++ b/OpenBCI_GUI/HardwareSettingsController.pde
@@ -241,11 +241,8 @@ class HardwareSettingsController{
             impedanceCheckValues[_numChannel-1][1] = onORoff;
         }
 
-        if (currentBoard instanceof BoardCyton) {
-            ((BoardCyton)currentBoard).setImpedanceSettings(_numChannel, pORn, onORoff == '1');
-        }
-        else if (currentBoard instanceof BoardNovaXR) {
-            ((BoardNovaXR)currentBoard).setImpedanceSettings(_numChannel, pORn, onORoff == '1');
+        if (currentBoard instanceof ImpedanceSettingsBoard) {
+            ((ImpedanceSettingsBoard)currentBoard).setImpedanceSettings(_numChannel, pORn, onORoff == '1');
         }
         else {
             outputError("Impedance settings not implemented for this board");

--- a/OpenBCI_GUI/ImpedanceSettingsBoard.pde
+++ b/OpenBCI_GUI/ImpedanceSettingsBoard.pde
@@ -1,0 +1,5 @@
+
+interface ImpedanceSettingsBoard {
+
+    public abstract void setImpedanceSettings(int channel, char pORn, boolean active);
+};

--- a/OpenBCI_GUI/W_GanglionImpedance.pde
+++ b/OpenBCI_GUI/W_GanglionImpedance.pde
@@ -96,7 +96,10 @@ class W_GanglionImpedance extends Widget {
         // todo[brainflow] needs just a little more work to reach feature parity, see comment below
         if (startStopCheck.isActive && startStopCheck.isMouseHere()) {
             if (currentBoard instanceof BoardGanglion) {
-                if (!((BoardGanglion)currentBoard).isCheckingImpedance()) {
+                // ganglion is the only board which can check impedance, so we don't have an interface for it.
+                // if that changes in the future, consider making an interface.
+                BoardGanglion ganglionBoard = (BoardGanglion)currentBoard;
+                if (!ganglionBoard.isCheckingImpedance()) {
                     // if is running... stopRunning and switch the state of the Start/Stop button back to Data Stream stopped
                     //stopRunning();
                     // We need to either stop the time series data, or allow it to scroll, like currently. 
@@ -105,11 +108,11 @@ class W_GanglionImpedance extends Widget {
                     topNav.stopButton.setColorNotPressed(color(184, 220, 105));
                     println("Starting Ganglion impedance check...");
                     //Start impedance check
-                    ((BoardGanglion)currentBoard).setImpedanceSettings(true);
+                    ganglionBoard.setCheckingImpedance(true);
                     startStopCheck.but_txt = "Stop Impedance Check";
                 } else {
                     //Stop impedance check
-                    ((BoardGanglion)currentBoard).setImpedanceSettings(false);
+                    ganglionBoard.setCheckingImpedance(false);
                     //ganglion.impedanceStop();
                     startStopCheck.but_txt = "Start Impedance Check";
                 }


### PR DESCRIPTION
BoardCyton and BoardNovaXR implement interface `ImpedanceSettingsBoard` since they both share the `setImpedanceSettings()` function.

In Ganglion, I renamed `setImpedanceSettings` to `setCheckingImpedance`. Is had the same name as the Cyton/NovaXR function but it did something completely different... I did not make an interface for `setCheckingImpedance` and `isCheckingImpedance` because Ganglion is the only one that needs those.
