### PR TITLE
fix session restart issue

### DIFF
--- a/OpenBCI_GUI/BoardBrainflow.pde
+++ b/OpenBCI_GUI/BoardBrainflow.pde
@@ -95,7 +95,6 @@ abstract class BoardBrainFlow implements Board {
             // and it looks like smth processing specific
             try {
                 BoardShim.enable_dev_board_logger();
-                BoardShim.set_log_file("brainflow_log.txt");
             } catch (BrainFlowError e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

@retiutut @daniellasry it fixes invalid memory access in session restart.
I will check if multiple set_log_file calls work in brainflow and if not I will fix it there too.
Here stderr is ok, so lets just remove set_log_file call