### PR TITLE
Fixed choppy data streaming

### DIFF
--- a/OpenBCI_GUI/BoardBrainflow.pde
+++ b/OpenBCI_GUI/BoardBrainflow.pde
@@ -8,6 +8,7 @@ abstract class BoardBrainFlow implements Board {
 
     protected int samplingRate = 0;
     protected int packetNumberChannel = 0;
+    protected int timeStampChannel = 0;
     protected int[] dataChannels = {};
     protected int[] accelChannels = {};
 
@@ -76,6 +77,7 @@ abstract class BoardBrainFlow implements Board {
         try {
             samplingRate = BoardShim.get_sampling_rate(getBoardIdInt());
             packetNumberChannel = BoardShim.get_package_num_channel(getBoardIdInt());
+            timeStampChannel = BoardShim.get_timestamp_channel(getBoardIdInt());
             dataChannels = getEXGChannels();
             accelChannels = BoardShim.get_accel_channels(getBoardIdInt());
         } catch (BrainFlowError e) {
@@ -128,10 +130,8 @@ abstract class BoardBrainFlow implements Board {
         }
 
         double[][] data;
-        int timestamp_channel = 0;
         try {
             data = boardShim.get_board_data();
-            timestamp_channel = BoardShim.get_timestamp_channel (getBoardIdInt());
         }
         catch (BrainFlowError e) {
             println ("ERROR: Exception trying to get board data");
@@ -152,12 +152,12 @@ abstract class BoardBrainFlow implements Board {
             curDataPacketInd = (curDataPacketInd+1) % dataPacketBuff.length;
             dataPacket.copyTo(dataPacketBuff[curDataPacketInd]);
         }
-        timestamps = Arrays.copyOfRange (data[timestamp_channel], 0, data[timestamp_channel].length);
     }
 
     protected void fillDataPacketWithValues(DataPacket_ADS1299 dataPacket, double[] values) {
 
         dataPacket.sampleIndex = (int)Math.round(values[packetNumberChannel]);
+        dataPacket.timeStamp = (long)values[timeStampChannel]*1000;
 
         for (int i=0; i < dataChannels.length; i++)
         {

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -61,23 +61,19 @@ int getDataIfAvailable(int pointCounter) {
     if (eegDataSource == DATASOURCE_CYTON) {
         //get data from serial port as it streams in
         //next, gather any new data into the "little buffer"
-        try {
-            while ( (curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate) && (timestamps.length != 0)) {
-                lastReadDataPacketInd = (lastReadDataPacketInd+1) % dataPacketBuff.length;  //increment to read the next packet
-                for (int Ichan=0; Ichan < nchan; Ichan++) {   //loop over each cahnnel
-                    //scale the data into engineering units ("microvolts") and save to the "little buffer"
-                    yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
-                }
-                for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
-                //println(timestamps.length);
-                long timestamp = (long) (timestamps[(pointCounter) % (timestamps.length+1)] * 1000);
-                // todo[brainflow] This method will be used to save data to ODF or BDF playback file
-                //println(timestamp + " | " + pointCounter % (timestamps.length + 1) + " of " + timestamps.length);
-                //saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  currentBoard.getLastValidAccelValues());
-                pointCounter++; //increment counter for "little buffer"
+        while ((curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
+            lastReadDataPacketInd = (lastReadDataPacketInd+1) % dataPacketBuff.length;  //increment to read the next packet
+            for (int Ichan=0; Ichan < nchan; Ichan++) {   //loop over each cahnnel
+                //scale the data into engineering units ("microvolts") and save to the "little buffer"
+                yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
             }
-        } catch (Exception e) {
-            //e.printStackTrace();
+            for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
+            //println(timestamps.length);
+            long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
+            // todo[brainflow] This method will be used to save data to ODF or BDF playback file
+            //println(timestamp + " | " + pointCounter % (timestamps.length + 1) + " of " + timestamps.length);
+            //saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  currentBoard.getLastValidAccelValues());
+            pointCounter++; //increment counter for "little buffer"
         }
     } else if (eegDataSource == DATASOURCE_GANGLION) {
         //get data from ble as it streams in

--- a/OpenBCI_GUI/Extras.pde
+++ b/OpenBCI_GUI/Extras.pde
@@ -206,12 +206,7 @@ String shortenString(String str, float maxWidth, PFont font) {
     return s1 + "..." + s2;
 }
 
-int lerpInt(int first, int second, float bias)
-{
-    return lerpLong(first, second, bias);    
-}
-
-int lerpLong(long first, long second, float bias)
+int lerpInt(long first, long second, float bias)
 {
     return round(lerp(first, second, bias));    
 }
@@ -240,7 +235,7 @@ DataPacket_ADS1299 CreateInterpolatedPacket(DataPacket_ADS1299 first, DataPacket
     }
 
     interpolated.sampleIndex = lerpInt(first.sampleIndex, second.sampleIndex, bias);
-    interpolated.timeStamp = lerpLong(first.timeStamp, second.timeStamp, bias);
+    interpolated.timeStamp = lerpInt(first.timeStamp, second.timeStamp, bias);
 
     return interpolated;
 }

--- a/OpenBCI_GUI/Extras.pde
+++ b/OpenBCI_GUI/Extras.pde
@@ -208,6 +208,11 @@ String shortenString(String str, float maxWidth, PFont font) {
 
 int lerpInt(int first, int second, float bias)
 {
+    return lerpLong(first, second, bias);    
+}
+
+int lerpLong(long first, long second, float bias)
+{
     return round(lerp(first, second, bias));    
 }
 
@@ -235,6 +240,7 @@ DataPacket_ADS1299 CreateInterpolatedPacket(DataPacket_ADS1299 first, DataPacket
     }
 
     interpolated.sampleIndex = lerpInt(first.sampleIndex, second.sampleIndex, bias);
+    interpolated.timeStamp = lerpLong(first.timeStamp, second.timeStamp, bias);
 
     return interpolated;
 }
@@ -264,6 +270,7 @@ class DataPacket_ADS1299 {
     private final int rawAuxSize = 2;
 
     int sampleIndex;
+    long timeStamp;
     int[] values;
     int[] auxValues;
     byte[][] rawValues;
@@ -285,6 +292,7 @@ class DataPacket_ADS1299 {
     int copyTo(DataPacket_ADS1299 target) { return copyTo(target, 0, 0); }
     private int copyTo(DataPacket_ADS1299 target, int target_startInd_values, int target_startInd_aux) {
         target.sampleIndex = sampleIndex;
+        target.timeStamp = timeStamp;
         return copyValuesAndAuxTo(target, target_startInd_values, target_startInd_aux);
     }
     int copyValuesAndAuxTo(DataPacket_ADS1299 target, int target_startInd_values, int target_startInd_aux) {

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -180,7 +180,6 @@ float yLittleBuff_uV[][]; //small buffer used to send data to the filters
 float accelerometerBuff[][]; // accelerometer buff 500 points
 float auxBuff[][];
 float data_elec_imp_ohm[];
-double timestamps[];
 
 float displayTime_sec = 20f;    //define how much time is shown on the time-domain montage plot (and how much is used in the FFT plot?)
 float dataBuff_len_sec = displayTime_sec + 3f; //needs to be wider than actual display so that filter startup is hidden


### PR DESCRIPTION
Removed global timestamps array, added timestamps to datapacket struct. This way we're guaranteed every packet has a timestamp.

Removed try/catch in dataprocessing.pde