### PR TITLE
Appveyour

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ clone_depth: 3
 build: off
 
 install:
-  - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && Start-FileDownload 'https://download.processing.org/processing-3.5.4-windows64.zip'
+  - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile 'https://download.processing.org/processing-3.5.4-windows64.zip'
   - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip && ls 
   # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
   - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ build: off
 
 install:
   - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile https://download.processing.org/processing-3.5.4-windows64.zip
-  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip -y > nul && ls 
+  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z x processing-3.5.4-windows64.zip -y -aoa && ls 
   # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
   - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"
   # cp libraries

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+image:
+- Visual Studio 2017
+
+stack: python 3
+
+clone_depth: 3
+
+build: off
+
+install:
+  - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && Start-FileDownload 'https://download.processing.org/processing-3.5.4-windows64.zip'
+  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip && ls 
+  # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
+  - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"
+  # cp libraries
+  - xcopy %APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\libraries\* %userprofile%\documents\processing\libraries /s /i
+
+test_script:
+  - echo "running processing" && %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build
+
+notifications:
+  - provider: Email
+    to:
+      - '{{commitAuthorEmail}}'
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ clone_depth: 3
 build: off
 
 install:
-  - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile 'https://download.processing.org/processing-3.5.4-windows64.zip'
+  - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile https://download.processing.org/processing-3.5.4-windows64.zip
   - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip && ls 
   # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
   - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ build: off
 
 install:
   - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile https://download.processing.org/processing-3.5.4-windows64.zip
-  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z x processing-3.5.4-windows64.zip -y -aoa && ls 
+  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z x processing-3.5.4-windows64.zip -y -aoa
   # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
   - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"
   # cp libraries

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ build: off
 
 install:
   - mkdir %APPVEYOR_BUILD_FOLDER%\temp && cd %APPVEYOR_BUILD_FOLDER%\temp && appveyor DownloadFile https://download.processing.org/processing-3.5.4-windows64.zip
-  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip && ls 
+  - cd %APPVEYOR_BUILD_FOLDER%\temp && 7z e processing-3.5.4-windows64.zip -y > nul && ls 
   # Processing creates Processing folder in Documents if there is no one, run it with error to create folder
   - echo "running processing" || %APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build || echo "set ec to 0"
   # cp libraries


### PR DESCRIPTION
add appveyour to openbci gui, currently just check 
```
%APPVEYOR_BUILD_FOLDER%\temp\processing-3.5.4\processing-java.exe --force --sketch=%APPVEYOR_BUILD_FOLDER%\OpenBCI_GUI\ --output=%APPVEYOR_BUILD_FOLDER%\tmp --build
```
@daniellasry I used your appveyour account, you have already added me as a colaborator and we use it for BrainFlow. Lets add @retiutut as a colaborator to it too.
We can do the same for macos/linux using travis-ci. @retiutut maybe for learning purposes and if you are interested you can try to add it later. Its not crucial right now because java is xplatform from the box and we dont release packages in CI right now 
