### PR TITLE
Fix DataLogging for all Live data Modes

### DIFF
--- a/OpenBCI_GUI/BoardBrainflow.pde
+++ b/OpenBCI_GUI/BoardBrainflow.pde
@@ -157,7 +157,7 @@ abstract class BoardBrainFlow implements Board {
     protected void fillDataPacketWithValues(DataPacket_ADS1299 dataPacket, double[] values) {
 
         dataPacket.sampleIndex = (int)Math.round(values[packetNumberChannel]);
-        dataPacket.timeStamp = (long)values[timeStampChannel]*1000;
+        dataPacket.timeStamp = (long) (values[timeStampChannel]*1000);
 
         for (int i=0; i < dataChannels.length; i++)
         {

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -58,7 +58,7 @@ int getDataIfAvailable(int pointCounter) {
     }
 
     // todo[brainflow] - this code here is just a copypaste get rid of it
-    if (eegDataSource == DATASOURCE_CYTON) {
+    if (currentBoard instanceof BoardCyton) {
         //get data from serial port as it streams in
         //next, gather any new data into the "little buffer"
         while ((curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
@@ -72,7 +72,7 @@ int getDataIfAvailable(int pointCounter) {
             long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
             // todo[brainflow] This method will be used to save data to ODF or BDF playback file
             //println(timestamp + " | " + pointCounter % (timestamps.length + 1) + " of " + timestamps.length);
-            //saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  currentBoard.getLastValidAccelValues());
+            saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  ((AccelerometerCapableBoard)currentBoard).getLastValidAccelValues());
             pointCounter++; //increment counter for "little buffer"
         }
     } else if (eegDataSource == DATASOURCE_GANGLION) {

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -70,8 +70,8 @@ int getDataIfAvailable(int pointCounter) {
                 //scale the data into engineering units ("microvolts") and save to the "little buffer"
                 yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
             }
-            //for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
-            if (eegDataSource != DATASOURCE_SYNTHETIC) {
+            if (currentBoard instanceof BoardCyton ||
+                currentBoard instanceof BoardGanglion ||) {
                 long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
                 saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  ((AccelerometerCapableBoard)currentBoard).getLastValidAccelValues());
             }

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -58,24 +58,10 @@ int getDataIfAvailable(int pointCounter) {
     }
 
     // todo[brainflow] - this code here is just a copypaste get rid of it
-    if (currentBoard instanceof BoardCyton) {
-        //get data from serial port as it streams in
-        //next, gather any new data into the "little buffer"
-        while ((curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
-            lastReadDataPacketInd = (lastReadDataPacketInd+1) % dataPacketBuff.length;  //increment to read the next packet
-            for (int Ichan=0; Ichan < nchan; Ichan++) {   //loop over each cahnnel
-                //scale the data into engineering units ("microvolts") and save to the "little buffer"
-                yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
-            }
-            for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
-            //println(timestamps.length);
-            long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
-            // todo[brainflow] This method will be used to save data to ODF or BDF playback file
-            //println(timestamp + " | " + pointCounter % (timestamps.length + 1) + " of " + timestamps.length);
-            saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  ((AccelerometerCapableBoard)currentBoard).getLastValidAccelValues());
-            pointCounter++; //increment counter for "little buffer"
-        }
-    } else if (eegDataSource == DATASOURCE_GANGLION) {
+    if (currentBoard instanceof BoardCyton ||
+        currentBoard instanceof BoardGanglion ||
+        currentBoard instanceof BoardNovaXR ||
+        currentBoard instanceof BoardSynthetic) {
         //get data from ble as it streams in
         //next, gather any new data into the "little buffer"
         while ( (curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
@@ -84,31 +70,11 @@ int getDataIfAvailable(int pointCounter) {
                 //scale the data into engineering units ("microvolts") and save to the "little buffer"
                 yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
             }
-            pointCounter++; //increment counter for "little buffer"
-        }
-
-    } else if (eegDataSource == DATASOURCE_NOVAXR) {
-        while ( (curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
-            lastReadDataPacketInd = (lastReadDataPacketInd+1) % dataPacketBuff.length;  //increment to read the next packet
-            
-            for (int Ichan=0; Ichan < nchan; Ichan++) {   //loop over each cahnnel
-                //scale the data into engineering units ("microvolts") and save to the "little buffer"
-                yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan];
+            //for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
+            if (eegDataSource != DATASOURCE_SYNTHETIC) {
+                long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
+                saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  ((AccelerometerCapableBoard)currentBoard).getLastValidAccelValues());
             }
-            for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
-            pointCounter++; //increment counter for "little buffer"
-        }
-
-    } else if (eegDataSource == DATASOURCE_SYNTHETIC) {
-
-        while ( (curDataPacketInd != lastReadDataPacketInd) && (pointCounter < nPointsPerUpdate)) {
-            lastReadDataPacketInd = (lastReadDataPacketInd+1) % dataPacketBuff.length;  //increment to read the next packet
-            
-            for (int Ichan=0; Ichan < nchan; Ichan++) {   //loop over each cahnnel
-                //scale the data into engineering units ("microvolts") and save to the "little buffer"
-                yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
-            }
-            for (int auxChan=0; auxChan < 3; auxChan++) auxBuff[auxChan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].auxValues[auxChan];
             pointCounter++; //increment counter for "little buffer"
         }
 

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -71,7 +71,7 @@ int getDataIfAvailable(int pointCounter) {
                 yLittleBuff_uV[Ichan][pointCounter] = dataPacketBuff[lastReadDataPacketInd].values[Ichan] * scaler;
             }
             if (currentBoard instanceof BoardCyton ||
-                currentBoard instanceof BoardGanglion ||) {
+                currentBoard instanceof BoardGanglion) {
                 long timestamp = dataPacketBuff[lastReadDataPacketInd].timeStamp;
                 saveDataToFile(scaler, lastReadDataPacketInd, timestamp,  ((AccelerometerCapableBoard)currentBoard).getLastValidAccelValues());
             }

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -173,7 +173,6 @@ float dataBuffY_filtY_uV[][];
 float yLittleBuff[];
 float yLittleBuff_uV[][]; //small buffer used to send data to the filters
 float accelerometerBuff[][]; // accelerometer buff 500 points
-float auxBuff[][];
 float data_elec_imp_ohm[];
 
 float displayTime_sec = 20f;    //define how much time is shown on the time-domain montage plot (and how much is used in the FFT plot?)
@@ -852,7 +851,6 @@ void initCoreDataObjects() {
     dataBuffY_filtY_uV = new float[nchan][dataBuffX.length];
     yLittleBuff = new float[nPointsPerUpdate];
     yLittleBuff_uV = new float[nchan][nPointsPerUpdate]; //small buffer used to send data to the filters
-    auxBuff = new float[3][nPointsPerUpdate];
     accelerometerBuff = new float[3][500]; // 500 points = 25Hz * 20secs(Max Window)
     for (int i=0; i<n_aux_ifEnabled; i++) {
         for (int j=0; j<accelerometerBuff[0].length; j++) {

--- a/OpenBCI_GUI/WidgetManager.pde
+++ b/OpenBCI_GUI/WidgetManager.pde
@@ -47,12 +47,10 @@ void setupWidgets(PApplet _this, ArrayList<Widget> w){
     addWidget(w_fft, w);
     // println("  setupWidgets fft -- " + millis());
 
-    if (currentBoard instanceof AccelerometerCapableBoard) {
-        //Widget_2
-        w_accelerometer = new W_Accelerometer(_this);
-        w_accelerometer.setTitle("Accelerometer");
-        addWidget(w_accelerometer, w);
-    }
+    //Widget_2
+    w_accelerometer = new W_Accelerometer(_this);
+    w_accelerometer.setTitle("Accelerometer");
+    addWidget(w_accelerometer, w);
 
     //only instantiate this widget if you are using a Ganglion board for live streaming
     if(nchan == 4 && currentBoard instanceof BoardGanglion){

--- a/OpenBCI_GUI/WidgetManager.pde
+++ b/OpenBCI_GUI/WidgetManager.pde
@@ -48,9 +48,11 @@ void setupWidgets(PApplet _this, ArrayList<Widget> w){
     // println("  setupWidgets fft -- " + millis());
 
     //Widget_2
-    w_accelerometer = new W_Accelerometer(_this);
-    w_accelerometer.setTitle("Accelerometer");
-    addWidget(w_accelerometer, w);
+    if(!(currentBoard instanceof BoardNovaXR)){
+        w_accelerometer = new W_Accelerometer(_this);
+        w_accelerometer.setTitle("Accelerometer");
+        addWidget(w_accelerometer, w);
+    }
 
     //only instantiate this widget if you are using a Ganglion board for live streaming
     if(nchan == 4 && currentBoard instanceof BoardGanglion){


### PR DESCRIPTION
- [x] Need help adding a method somewhere to consume `get_timestamp_channel()` from Brainflow boards #680 
- [x] Get timestamp and pass this to `saveDataToFile()` instead of `new Date().getTime()`
- [x] Ensure millisecond accuracy for timestamp saved to file
- [x] Check that timestamps progress logically (time --->)
- [x] Cyton Accel
- [ ] Cyton Analog Mode
- [ ] Cyton Digital Mode
- [x] Ganglion
- [x] Cyton+WiFi
- [x] Ganglion+WiFi
- [ ] Double check using Windows and Linux
