### PR TITLE
Made it so uninitialized boards can still return channel indices.

### DIFF
--- a/OpenBCI_GUI/BoardBrainFlowSynthetic.pde
+++ b/OpenBCI_GUI/BoardBrainFlowSynthetic.pde
@@ -3,26 +3,9 @@ import brainflow.*;
 class BoardBrainFlowSynthetic extends BoardBrainFlow
 implements AccelerometerCapableBoard, PPGCapableBoard, EDACapableBoard {
 
-    private int[] accelChannels = {};
-    private int[] edaChannels = {};
-    private int[] ppgChannels = {};
-
-    @Override
-    public boolean initializeInternal() {
-        boolean res = super.initializeInternal();
-
-        try {
-            accelChannels = BoardShim.get_accel_channels(getBoardIdInt());
-            edaChannels = BoardShim.get_eda_channels(getBoardIdInt());
-            ppgChannels = BoardShim.get_ppg_channels(getBoardIdInt());
-
-        } catch (BrainFlowError e) {
-            e.printStackTrace();
-            res = false;
-        }
-
-        return res;
-    }
+    private int[] accelChannelsCache = null;
+    private int[] edaChannelsCache = null;
+    private int[] ppgChannelsCache = null;
 
     // implement mandatory abstract functions
     @Override
@@ -59,7 +42,16 @@ implements AccelerometerCapableBoard, PPGCapableBoard, EDACapableBoard {
 
     @Override
     public int[] getAccelerometerChannels() {
-        return accelChannels;
+        if (accelChannelsCache == null) {
+            try {
+                accelChannelsCache = BoardShim.get_accel_channels(getBoardIdInt());
+
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return accelChannelsCache;
     }
 
     @Override
@@ -74,7 +66,16 @@ implements AccelerometerCapableBoard, PPGCapableBoard, EDACapableBoard {
 
     @Override
     public int[] getPPGChannels() {
-        return ppgChannels;
+        if(ppgChannelsCache == null) {
+            try {
+                ppgChannelsCache = BoardShim.get_ppg_channels(getBoardIdInt());
+
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return ppgChannelsCache;
     }
 
     @Override
@@ -89,19 +90,28 @@ implements AccelerometerCapableBoard, PPGCapableBoard, EDACapableBoard {
 
     @Override
     public int[] getEDAChannels() {
-        return edaChannels;
+        if (edaChannelsCache == null) {
+            try {
+                edaChannelsCache = BoardShim.get_eda_channels(getBoardIdInt());
+
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return edaChannelsCache;
     }
     
     @Override
     protected void addChannelNamesInternal(String[] channelNames) {
-        for (int i=0; i<edaChannels.length; i++) {
-            channelNames[edaChannels[i]] = "EDA Channel " + i;
+        for (int i=0; i<getEDAChannels().length; i++) {
+            channelNames[getEDAChannels()[i]] = "EDA Channel " + i;
         }
-        for (int i=0; i<ppgChannels.length; i++) {
-            channelNames[ppgChannels[i]] = "PPG Channel " + i;
+        for (int i=0; i<getPPGChannels().length; i++) {
+            channelNames[getPPGChannels()[i]] = "PPG Channel " + i;
         }
-        for (int i=0; i<accelChannels.length; i++) {
-            channelNames[accelChannels[i]] = "Accel Channel " + i;
+        for (int i=0; i<getAccelerometerChannels().length; i++) {
+            channelNames[getAccelerometerChannels()[i]] = "Accel Channel " + i;
         }
     }
 };

--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -29,8 +29,9 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     private final char[] activateChannelChars = {'!', '@', '#', '$', '%', '^', '&', '*', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
     private final char[] channelSelectForSettings = {'1', '2', '3', '4', '5', '6', '7', '8', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
     
-    private int[] accelChannels;
-    private int[] analogChannels;
+    private int[] accelChannelsCache = null;
+    private int[] analogChannelsCache = null;
+
     private boolean[] exgChannelActive;
 
     private String serialPort = "";
@@ -74,21 +75,11 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     }
 
     @Override
-    public boolean initializeInternal() {
-        boolean res = super.initializeInternal();
-
-        try {
-            accelChannels = BoardShim.get_accel_channels(getBoardIdInt());
-            analogChannels = BoardShim.get_analog_channels(getBoardIdInt());
-        } catch (BrainFlowError e) {
-            e.printStackTrace();
-            res = false;
-        }
-        
+    public boolean initializeInternal() {        
         exgChannelActive = new boolean[getNumEXGChannels()];
         Arrays.fill(exgChannelActive, true);
 
-        return res;
+        return super.initializeInternal();
     }
 
     @Override
@@ -124,7 +115,15 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
 
     @Override
     public int[] getAccelerometerChannels() {
-        return accelChannels;
+        if (accelChannelsCache == null) {
+            try {
+                accelChannelsCache = BoardShim.get_accel_channels(getBoardIdInt());
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return accelChannelsCache;
     }
 
     @Override
@@ -143,7 +142,15 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
 
     @Override
     public int[] getAnalogChannels() {
-        return analogChannels;
+        if (analogChannelsCache == null) {
+            try {
+                analogChannelsCache = BoardShim.get_analog_channels(getBoardIdInt());
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return analogChannelsCache;
     }
 
     @Override
@@ -239,11 +246,11 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
     
     @Override
     protected void addChannelNamesInternal(String[] channelNames) {
-        for (int i=0; i<accelChannels.length; i++) {
-            channelNames[accelChannels[i]] = "Accel Channel " + i;
+        for (int i=0; i<getAccelerometerChannels().length; i++) {
+            channelNames[getAccelerometerChannels()[i]] = "Accel Channel " + i;
         }
-        for (int i=0; i<analogChannels.length; i++) {
-            channelNames[analogChannels[i]] = "Analog Channel " + i;
+        for (int i=0; i<getAnalogChannels().length; i++) {
+            channelNames[getAnalogChannels()[i]] = "Analog Channel " + i;
         }
     }
 };

--- a/OpenBCI_GUI/BoardGanglion.pde
+++ b/OpenBCI_GUI/BoardGanglion.pde
@@ -3,7 +3,8 @@ class BoardGanglion extends BoardBrainFlow implements AccelerometerCapableBoard 
     private final char[] deactivateChannelChars = {'1', '2', '3', '4', '5', '6', '7', '8', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i'};
     private final char[] activateChannelChars =  {'!', '@', '#', '$', '%', '^', '&', '*', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I'};
     
-    private int[] accelChannels;
+    private int[] accelChannelsCache = null;
+
     private boolean[] exgChannelActive;
 
     private String serialPort = "";
@@ -61,15 +62,8 @@ class BoardGanglion extends BoardBrainFlow implements AccelerometerCapableBoard 
     {
         // turn on accel by default, or is it handled somewhere else?
         boolean res = super.initializeInternal();
-
-        try {
-            accelChannels = BoardShim.get_accel_channels(getBoardIdInt());
-            setAccelerometerActive(true);
-        } catch (BrainFlowError e) {
-            e.printStackTrace();
-            res = false;
-        }
         
+        setAccelerometerActive(true);
         exgChannelActive = new boolean[getNumEXGChannels()];
         Arrays.fill(exgChannelActive, true);
 
@@ -89,7 +83,15 @@ class BoardGanglion extends BoardBrainFlow implements AccelerometerCapableBoard 
 
     @Override
     public int[] getAccelerometerChannels() {
-        return accelChannels;
+        if (accelChannelsCache == null) {
+            try {
+                accelChannelsCache = BoardShim.get_accel_channels(getBoardIdInt());
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+        
+        return accelChannelsCache;
     }
 
     public void setCheckingImpedance(boolean checkImpedance) {
@@ -103,8 +105,8 @@ class BoardGanglion extends BoardBrainFlow implements AccelerometerCapableBoard 
     
     @Override
     protected void addChannelNamesInternal(String[] channelNames) {
-        for (int i=0; i<accelChannels.length; i++) {
-            channelNames[accelChannels[i]] = "Accel Channel " + i;
+        for (int i=0; i<getAccelerometerChannels().length; i++) {
+            channelNames[getAccelerometerChannels()[i]] = "Accel Channel " + i;
         }
     }
 };

--- a/OpenBCI_GUI/BoardSynthetic.pde
+++ b/OpenBCI_GUI/BoardSynthetic.pde
@@ -10,28 +10,30 @@ class BoardSynthetic extends Board implements AccelerometerCapableBoard {
     private float[] sine_phase_rad;
     private int lastSynthTime;
     private int samplingIntervalMS;
+    private boolean[] exgChannelActive;
+
     private int sampleNumberChannel;
     private int[] exgChannels;
     private int[] accelChannels;
     private int timestampChannel;
     private int totalChannels;
-    private boolean[] exgChannelActive;
+
 
     // Synthetic accel data timer. Track frame count for synthetic data.
     private int accelSynthTime;
 
-    public BoardSynthetic() {        
-    }
-
-    @Override
-    public boolean initializeInternal() {
+    public BoardSynthetic() {    
         totalChannels = 0;
         sampleNumberChannel = totalChannels++;
         exgChannels = range(totalChannels, totalChannels + nchan);
         totalChannels += nchan;
         accelChannels = range(totalChannels, totalChannels + NUM_ACCEL_DIMS);
         totalChannels += NUM_ACCEL_DIMS;
-        timestampChannel = totalChannels++;
+        timestampChannel = totalChannels++;    
+    }
+
+    @Override
+    public boolean initializeInternal() {
 
         exgChannelActive = new boolean[exgChannels.length];
         Arrays.fill(exgChannelActive, true);

--- a/OpenBCI_GUI/DataWriterODF.pde
+++ b/OpenBCI_GUI/DataWriterODF.pde
@@ -22,6 +22,7 @@ public class DataWriterODF {
         output.println("%OpenBCI Raw EEG Data");
         output.println("%Number of channels = " + nchan);
         output.println("%Sample Rate = " + currentBoard.getSampleRate() + " Hz");
+        output.println("%Board = " + currentBoard.getClass().getName());
 
         String[] colNames = currentBoard.getChannelNames();
         


### PR DESCRIPTION
My idea for BoardPlayback is to have it create a dummy instance of the original board internally, and use that instance to get channel indices.

For example, if we open a Cyton playback file, BoardPlayback will create a dummy instance of BoardCyton and use it to call getEXGChannels(), getAccelerometerChannels(), etc.

This is the first step towards that goal. Those functions need to work without having to call initalize() on the board.
