### PR TITLE
Fix bdf file writer

### DIFF
--- a/OpenBCI_GUI/DataLogger.pde
+++ b/OpenBCI_GUI/DataLogger.pde
@@ -7,6 +7,10 @@ class DataLogger {
 
     }
 
+    ~DataLogger() {
+        closeLogFile();
+    }
+
     public void initialize() {
 
     }

--- a/OpenBCI_GUI/DataLogger.pde
+++ b/OpenBCI_GUI/DataLogger.pde
@@ -1,7 +1,7 @@
 class DataLogger {
     //variables for writing EEG data out to a file
     private DataWriterODF fileWriterODF;
-    private OutputFile_BDF fileoutput_bdf;
+    private DataWriterBDF fileWriterBDF;
 
     DataLogger() {
 
@@ -39,7 +39,7 @@ class DataLogger {
             case OUTPUT_SOURCE_BDF:
                 // curBDFDataPacketInd = curDataPacketInd;
                 // thread("writeRawData_dataPacket_bdf");
-                fileoutput_bdf.writeRawData_dataPacket(dataPacketBuff[curDataPacketInd]);
+                fileWriterBDF.writeRawData_dataPacket(newData);
                 break;
             case OUTPUT_SOURCE_NONE:
             default:
@@ -77,8 +77,8 @@ class DataLogger {
             return float(fileWriterODF.getRowsWritten())/getSampleRateSafe();
         }
         
-        if (outputDataSource == OUTPUT_SOURCE_BDF && fileoutput_bdf != null) {
-            return fileoutput_bdf.getRecordsWritten();
+        if (outputDataSource == OUTPUT_SOURCE_BDF && fileWriterBDF != null) {
+            return fileWriterBDF.getRecordsWritten();
         }
 
         return 0.f;
@@ -107,14 +107,14 @@ class DataLogger {
     * @param `_fileName` {String} - The meat of the file name
     */
     private void openNewLogFileBDF(String _fileName) {
-        if (fileoutput_bdf != null) {
+        if (fileWriterBDF != null) {
             println("OpenBCI_GUI: closing log file");
             closeLogFile();
         }
         //open the new file
-        fileoutput_bdf = new OutputFile_BDF(getSampleRateSafe(), nchan, _fileName);
+        fileWriterBDF = new DataWriterBDF(_fileName);
 
-        output_fname = fileoutput_bdf.fname;
+        output_fname = fileWriterBDF.fname;
         println("OpenBCI_GUI: openNewLogFile: opened BDF output file: " + output_fname); //Print filename of new BDF file to console
     }
 
@@ -156,10 +156,10 @@ class DataLogger {
     *  records.
     */
     private void closeLogFileBDF() {
-        if (fileoutput_bdf != null) {
-            fileoutput_bdf.closeFile();
+        if (fileWriterBDF != null) {
+            fileWriterBDF.closeFile();
         }
-        fileoutput_bdf = null;
+        fileWriterBDF = null;
     }
 
     /**

--- a/OpenBCI_GUI/DataLogger.pde
+++ b/OpenBCI_GUI/DataLogger.pde
@@ -7,10 +7,6 @@ class DataLogger {
 
     }
 
-    ~DataLogger() {
-        closeLogFile();
-    }
-
     public void initialize() {
 
     }

--- a/OpenBCI_GUI/DataLogger.pde
+++ b/OpenBCI_GUI/DataLogger.pde
@@ -12,9 +12,11 @@ class DataLogger {
     }
 
     public void uninitialize() {
-        if (eegDataSource != DATASOURCE_PLAYBACKFILE){
-            closeLogFile();  //close log file
-        } 
+        closeLogFile();  //close log file
+    }
+
+    public void onShutDown() {
+        closeLogFile();  //close log file
     }
 
     public void update() {

--- a/OpenBCI_GUI/DataWriterBDF.pde
+++ b/OpenBCI_GUI/DataWriterBDF.pde
@@ -807,10 +807,10 @@ public class DataWriterBDF {
             ByteBuffer bb = ByteBuffer.allocate(4); 
             bb.putInt(value); 
             byte[] bytes = bb.array();
+            // skip the first byte which should be full of zeroes anyway (24 bit int)
             byte[] values = {bytes[1], bytes[2], bytes[3]};
 
             // Make the values little endian
-            // skip the first byte which sould be full of zeroes anyway (24 bit int)
             chanValBuf[i][samplesInDataRecord][0] = values[2];
             chanValBuf[i][samplesInDataRecord][1] = values[1];
             chanValBuf[i][samplesInDataRecord][2] = values[0];
@@ -836,6 +836,7 @@ public class DataWriterBDF {
                 ByteBuffer bb = ByteBuffer.allocate(4); 
                 bb.putInt(accelInt);
                 byte[] bytes = bb.array();
+                // skip the first 2 bytes which should be full of zeroes anyway (16 bit int)
                 byte[] values = {bytes[2], bytes[3]};
 
                 // grab the lower part of

--- a/OpenBCI_GUI/DataWriterBDF.pde
+++ b/OpenBCI_GUI/DataWriterBDF.pde
@@ -168,6 +168,10 @@ public class DataWriterBDF {
         init();
     }
 
+    ~DataWriterBDF() {
+        closeFile();
+    }
+
     /**
       * @description Used to initalize the writer.
       */

--- a/OpenBCI_GUI/DataWriterBDF.pde
+++ b/OpenBCI_GUI/DataWriterBDF.pde
@@ -167,11 +167,7 @@ public class DataWriterBDF {
 
         init();
     }
-
-    ~DataWriterBDF() {
-        closeFile();
-    }
-
+    
     /**
       * @description Used to initalize the writer.
       */

--- a/OpenBCI_GUI/DataWriterODF.pde
+++ b/OpenBCI_GUI/DataWriterODF.pde
@@ -21,10 +21,6 @@ public class DataWriterODF {
         rowsWritten = 0;    //init the counter
     }
 
-    ~DataWriterODF() {
-        closeFile();
-    }
-
     public void writeHeader() {
         output.println("%OpenBCI Raw EEG Data");
         output.println("%Number of channels = " + nchan);

--- a/OpenBCI_GUI/DataWriterODF.pde
+++ b/OpenBCI_GUI/DataWriterODF.pde
@@ -21,6 +21,10 @@ public class DataWriterODF {
         rowsWritten = 0;    //init the counter
     }
 
+    ~DataWriterODF() {
+        closeFile();
+    }
+
     public void writeHeader() {
         output.println("%OpenBCI Raw EEG Data");
         output.println("%Number of channels = " + nchan);

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -510,6 +510,9 @@ private void prepareExitHandler () {
             } catch (Exception ex) {
                 ex.printStackTrace(); // not much else to do at this point
             }
+
+            // finalize any playback files
+            dataLogger.onShutDown();
         }
     }
     ));


### PR DESCRIPTION
Wasn't too bad after all.

Main part of the change was updating writeChannelDataValues() and writeAuxDataValues() to take a double[][] as arguments and write the data in the same format. I had to convert from doubles back to an array of 3 bytes.