### PR TITLE
GUI v5 Networking Repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Missing Filter Button Label in Networking #696
 * Ganglion+WiFi Accelerometer Data not in Sync #512
 * General UI/UX improvements
+* Remove # Chan Textfield from LSL in Networking Widget #644
 
 ### Deprecated Features
 * OpenBCI Hub - This is no longer required to run the GUI!

--- a/OpenBCI_GUI/ADS1299SettingsController.pde
+++ b/OpenBCI_GUI/ADS1299SettingsController.pde
@@ -6,11 +6,11 @@ class ADS1299SettingsController{
 
     int spaceBetweenButtons = 5; //space between buttons
 
-    Button[] gainButtons;
-    Button[] inputTypeButtons;
-    Button[] biasButtons;
-    Button[] srb2Buttons;
-    Button[] srb1Buttons;
+    Button_obci[] gainButtons;
+    Button_obci[] inputTypeButtons;
+    Button_obci[] biasButtons;
+    Button_obci[] srb2Buttons;
+    Button_obci[] srb1Buttons;
 
     ADS1299Settings boardSettings;
 
@@ -73,18 +73,18 @@ class ADS1299SettingsController{
 
         int channelCount = currentBoard.getNumEXGChannels();
 
-        gainButtons = new Button[channelCount];
-        inputTypeButtons = new Button[channelCount];
-        biasButtons = new Button[channelCount];
-        srb2Buttons = new Button[channelCount];
-        srb1Buttons = new Button[channelCount];
+        gainButtons = new Button_obci[channelCount];
+        inputTypeButtons = new Button_obci[channelCount];
+        biasButtons = new Button_obci[channelCount];
+        srb2Buttons = new Button_obci[channelCount];
+        srb1Buttons = new Button_obci[channelCount];
 
         for (int i=0; i<channelCount; i++) {
-            gainButtons[i] = new Button(0, 0, 0, 0, "Unlabeled");
-            inputTypeButtons[i] = new Button(0, 0, 0, 0, "Unlabeled");
-            biasButtons[i] = new Button(0, 0, 0, 0, "Unlabeled");
-            srb2Buttons[i] = new Button(0, 0, 0, 0, "Unlabeled");
-            srb1Buttons[i] = new Button(0, 0, 0, 0, "Unlabeled");
+            gainButtons[i] = new Button_obci(0, 0, 0, 0, "Unlabeled");
+            inputTypeButtons[i] = new Button_obci(0, 0, 0, 0, "Unlabeled");
+            biasButtons[i] = new Button_obci(0, 0, 0, 0, "Unlabeled");
+            srb2Buttons[i] = new Button_obci(0, 0, 0, 0, "Unlabeled");
+            srb1Buttons[i] = new Button_obci(0, 0, 0, 0, "Unlabeled");
         }
 
         resizeButtons(_channelBarHeight);

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -72,45 +72,45 @@ color boxStrokeColor = color(bgColor);
 color isSelected_color = color(184, 220, 105);
 color colorNotPressed = color(255);
 
-Button refreshPort;
-Button refreshBLE;
-Button refreshWifi;
-Button protocolSerialCyton;
-Button protocolWifiCyton;
-Button protocolWifiGanglion;
-Button protocolBLED112Ganglion;
+Button_obci refreshPort;
+Button_obci refreshBLE;
+Button_obci refreshWifi;
+Button_obci protocolSerialCyton;
+Button_obci protocolWifiCyton;
+Button_obci protocolWifiGanglion;
+Button_obci protocolBLED112Ganglion;
 
-Button initSystemButton;
-Button autoSessionName; // Reuse these buttons for Cyton and Ganglion
-Button outputBDF;
-Button outputODF;
+Button_obci initSystemButton;
+Button_obci autoSessionName; // Reuse these buttons for Cyton and Ganglion
+Button_obci outputBDF;
+Button_obci outputODF;
 
-Button sampleDataButton; // Used to easily find GUI sample data for Playback mode #645
+Button_obci sampleDataButton; // Used to easily find GUI sample data for Playback mode #645
 
-Button chanButton8;
-Button chanButton16;
-Button selectPlaybackFile;
-Button selectSDFile;
-Button popOutRadioConfigButton;
+Button_obci chanButton8;
+Button_obci chanButton16;
+Button_obci selectPlaybackFile;
+Button_obci selectSDFile;
+Button_obci popOutRadioConfigButton;
 
-//Radio Button Definitions
-Button getChannel;
-Button setChannel;
-Button ovrChannel;
-Button autoscan;
-Button systemStatus;
+//Radio Button_obci Definitions
+Button_obci getChannel;
+Button_obci setChannel;
+Button_obci ovrChannel;
+Button_obci autoscan;
+Button_obci systemStatus;
 
-Button sampleRate200; //Ganglion
-Button sampleRate250; //Cyton
-Button sampleRate500; //Cyton
-Button sampleRate1000;  //Cyton
-Button sampleRate1600; //Ganglion
-Button wifiIPAddressDynamic;
-Button wifiIPAddressStatic;
+Button_obci sampleRate200; //Ganglion
+Button_obci sampleRate250; //Cyton
+Button_obci sampleRate500; //Cyton
+Button_obci sampleRate1000;  //Cyton
+Button_obci sampleRate1600; //Ganglion
+Button_obci wifiIPAddressDynamic;
+Button_obci wifiIPAddressStatic;
 
-Button synthChanButton4;
-Button synthChanButton8;
-Button synthChanButton16;
+Button_obci synthChanButton4;
+Button_obci synthChanButton8;
+Button_obci synthChanButton16;
 
 ChannelPopup channelPopup;
 PollPopup pollPopup;
@@ -1345,7 +1345,7 @@ class DataSourceBox {
 
 class SerialBox {
     int x, y, w, h, padding; //size and position
-    Button autoConnect;
+    Button_obci autoConnect;
 
     SerialBox(int _x, int _y, int _w, int _h, int _padding) {
         x = _x;
@@ -1354,9 +1354,9 @@ class SerialBox {
         h = 70;
         padding = _padding;
 
-        autoConnect = new Button(x + padding, y + padding*3 + 4, w - padding*3 - 70, 24, "AUTO-CONNECT", fontInfo.buttonLabel_size);
+        autoConnect = new Button_obci(x + padding, y + padding*3 + 4, w - padding*3 - 70, 24, "AUTO-CONNECT", fontInfo.buttonLabel_size);
         autoConnect.setHelpText("Attempt to auto-connect to Cyton. Try \"Manual\" if this does not work.");
-        popOutRadioConfigButton = new Button(x + w - 70 - padding, y + padding*3 + 4, 70, 24,"Manual >",fontInfo.buttonLabel_size);
+        popOutRadioConfigButton = new Button_obci(x + w - 70 - padding, y + padding*3 + 4, 70, 24,"Manual >",fontInfo.buttonLabel_size);
         popOutRadioConfigButton.setHelpText("Having trouble connecting to Cyton? Click here to access Radio Configuration tools.");
     }
 
@@ -1423,7 +1423,7 @@ class ComPortBox {
         padding = _padding;
         isShowing = false;
 
-        refreshPort = new Button (x + padding, y + padding*4 + 72 + 8, w - padding*2, 24, "REFRESH LIST", fontInfo.buttonLabel_size);
+        refreshPort = new Button_obci (x + padding, y + padding*4 + 72 + 8, w - padding*2, 24, "REFRESH LIST", fontInfo.buttonLabel_size);
         serialList = new MenuList(cp5, "serialList", w - padding*2, 72, p4);
         // println(w-padding*2);
         serialList.setPosition(x + padding, y + padding*3 + 8);
@@ -1461,7 +1461,7 @@ class BLEBox {
         w = _w;
         h = 140 + _padding;
         padding = _padding;
-        refreshBLE = new Button (x + padding, y + padding*4 + 72 + 8, w - padding*5, 24, "START SEARCH", fontInfo.buttonLabel_size);
+        refreshBLE = new Button_obci (x + padding, y + padding*4 + 72 + 8, w - padding*5, 24, "START SEARCH", fontInfo.buttonLabel_size);
         bleList = new MenuList(cp5, "bleList", w - padding*2, 72, p4);
         bleList.setPosition(x + padding, y + padding*3 + 8);
     }
@@ -1495,12 +1495,12 @@ class WifiBox {
         h = 184 + _padding + 14;
         padding = _padding;
 
-        wifiIPAddressDynamic = new Button (x + padding, y + padding*2 + 30, (w-padding*3)/2, 24, "DYNAMIC IP", fontInfo.buttonLabel_size);
+        wifiIPAddressDynamic = new Button_obci (x + padding, y + padding*2 + 30, (w-padding*3)/2, 24, "DYNAMIC IP", fontInfo.buttonLabel_size);
         wifiIPAddressDynamic.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
-        wifiIPAddressStatic = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 30, (w-padding*3)/2, 24, "STATIC IP", fontInfo.buttonLabel_size);
+        wifiIPAddressStatic = new Button_obci (x + padding*2 + (w-padding*3)/2, y + padding*2 + 30, (w-padding*3)/2, 24, "STATIC IP", fontInfo.buttonLabel_size);
         wifiIPAddressStatic.setColorNotPressed(colorNotPressed);
 
-        refreshWifi = new Button (x + padding, y + padding*5 + 72 + 8 + 24, w - padding*5, 24, "START SEARCH", fontInfo.buttonLabel_size);
+        refreshWifi = new Button_obci (x + padding, y + padding*5 + 72 + 8 + 24, w - padding*5, 24, "START SEARCH", fontInfo.buttonLabel_size);
         wifiList = new MenuList(cp5, "wifiList", w - padding*2, 72 + 8, p4);
 
         wifiList.setPosition(x + padding, y + padding*4 + 8 + 24);
@@ -1611,8 +1611,8 @@ class InterfaceBoxCyton {
         h = (24 + _padding) * 3;
         padding = _padding;
 
-        protocolSerialCyton = new Button (x + padding, y + padding * 3 + 4, w - padding * 2, 24, "Serial (from Dongle)", fontInfo.buttonLabel_size);
-        protocolWifiCyton = new Button (x + padding, y + padding * 4 + 24 + 4, w - padding * 2, 24, "Wifi (from Wifi Shield)", fontInfo.buttonLabel_size);
+        protocolSerialCyton = new Button_obci (x + padding, y + padding * 3 + 4, w - padding * 2, 24, "Serial (from Dongle)", fontInfo.buttonLabel_size);
+        protocolWifiCyton = new Button_obci (x + padding, y + padding * 4 + 24 + 4, w - padding * 2, 24, "Wifi (from Wifi Shield)", fontInfo.buttonLabel_size);
     }
 
     public void update() {}
@@ -1646,9 +1646,9 @@ class InterfaceBoxGanglion {
         int buttonHeight = 24;
 
         int paddingCount = 1;
-        protocolBLED112Ganglion = new Button (x + padding, y + padding * paddingCount + buttonHeight * paddingCount, w - padding * 2, 24, "Bluetooth (BLED112 Dongle)", fontInfo.buttonLabel_size);
+        protocolBLED112Ganglion = new Button_obci (x + padding, y + padding * paddingCount + buttonHeight * paddingCount, w - padding * 2, 24, "Bluetooth (BLED112 Dongle)", fontInfo.buttonLabel_size);
         paddingCount ++;
-        protocolWifiGanglion = new Button (x + padding, y + padding * paddingCount + buttonHeight * paddingCount, w - padding * 2, 24, "Wifi (from Wifi Shield)", fontInfo.buttonLabel_size);
+        protocolWifiGanglion = new Button_obci (x + padding, y + padding * paddingCount + buttonHeight * paddingCount, w - padding * 2, 24, "Wifi (from Wifi Shield)", fontInfo.buttonLabel_size);
         paddingCount ++;
     }
 
@@ -1695,13 +1695,13 @@ class SessionDataBox {
         maxDurTextWidth += padding*5 + 1;
 
         //button to autogenerate file name based on time/date
-        autoSessionName = new Button (x + padding, y + 66, w-(padding*2), 24, "GENERATE SESSION NAME", fontInfo.buttonLabel_size);
+        autoSessionName = new Button_obci (x + padding, y + 66, w-(padding*2), 24, "GENERATE SESSION NAME", fontInfo.buttonLabel_size);
         autoSessionName.setHelpText("Autogenerate a session name based on the date and time.");
-        outputODF = new Button (x + padding, y + padding*2 + 18 + 58, (w-padding*3)/2, 24, "OpenBCI", fontInfo.buttonLabel_size);
+        outputODF = new Button_obci (x + padding, y + padding*2 + 18 + 58, (w-padding*3)/2, 24, "OpenBCI", fontInfo.buttonLabel_size);
         outputODF.setHelpText("Set GUI data output to OpenBCI Data Format (.txt). A new file will be made in the session folder when the data stream is paused or max file duration is reached.");
         //Output source is ODF by default
         if (outputDataSource == OUTPUT_SOURCE_ODF) outputODF.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
-        outputBDF = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18 + 58, (w-padding*3)/2, 24, "BDF+", fontInfo.buttonLabel_size);
+        outputBDF = new Button_obci (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18 + 58, (w-padding*3)/2, 24, "BDF+", fontInfo.buttonLabel_size);
         outputBDF.setHelpText("Set GUI data output to BioSemi Data Format (.bdf). All session data is contained in one .bdf file. View using an EDF/BDF browser.");
         if (outputDataSource == OUTPUT_SOURCE_BDF) outputBDF.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
 
@@ -1894,9 +1894,9 @@ class ChannelCountBox {
         h = 73;
         padding = _padding;
 
-        chanButton8 = new Button (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "8 CHANNELS", fontInfo.buttonLabel_size);
+        chanButton8 = new Button_obci (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "8 CHANNELS", fontInfo.buttonLabel_size);
         if (nchan == 8) chanButton8.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
-        chanButton16 = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "16 CHANNELS", fontInfo.buttonLabel_size);
+        chanButton16 = new Button_obci (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "16 CHANNELS", fontInfo.buttonLabel_size);
         if (nchan == 16) chanButton16.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
     }
 
@@ -1936,8 +1936,8 @@ class SampleRateGanglionBox {
         h = 73;
         padding = _padding;
 
-        sampleRate200 = new Button (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "200Hz", fontInfo.buttonLabel_size);
-        sampleRate1600 = new Button (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "1600Hz", fontInfo.buttonLabel_size);
+        sampleRate200 = new Button_obci (x + padding, y + padding*2 + 18, (w-padding*3)/2, 24, "200Hz", fontInfo.buttonLabel_size);
+        sampleRate1600 = new Button_obci (x + padding*2 + (w-padding*3)/2, y + padding*2 + 18, (w-padding*3)/2, 24, "1600Hz", fontInfo.buttonLabel_size);
         sampleRate1600.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
     }
 
@@ -1976,9 +1976,9 @@ class SampleRateCytonBox {
         h = 73;
         padding = _padding;
 
-        sampleRate250 = new Button (x + padding, y + padding*2 + 18, (w-padding*4)/3, 24, "250Hz", fontInfo.buttonLabel_size);
-        sampleRate500 = new Button (x + padding*2 + (w-padding*4)/3, y + padding*2 + 18, (w-padding*4)/3, 24, "500Hz", fontInfo.buttonLabel_size);
-        sampleRate1000 = new Button (x + padding*3 + ((w-padding*4)/3)*2, y + padding*2 + 18, (w-padding*4)/3, 24, "1000Hz", fontInfo.buttonLabel_size);
+        sampleRate250 = new Button_obci (x + padding, y + padding*2 + 18, (w-padding*4)/3, 24, "250Hz", fontInfo.buttonLabel_size);
+        sampleRate500 = new Button_obci (x + padding*2 + (w-padding*4)/3, y + padding*2 + 18, (w-padding*4)/3, 24, "500Hz", fontInfo.buttonLabel_size);
+        sampleRate1000 = new Button_obci (x + padding*3 + ((w-padding*4)/3)*2, y + padding*2 + 18, (w-padding*4)/3, 24, "1000Hz", fontInfo.buttonLabel_size);
         sampleRate1000.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
     }
 
@@ -2019,11 +2019,11 @@ class SyntheticChannelCountBox {
         h = 73;
         padding = _padding;
 
-        synthChanButton4 = new Button (x + padding, y + padding*2 + 18, (w-padding*4)/3, 24, "4 chan", fontInfo.buttonLabel_size);
+        synthChanButton4 = new Button_obci (x + padding, y + padding*2 + 18, (w-padding*4)/3, 24, "4 chan", fontInfo.buttonLabel_size);
         if (nchan == 4) synthChanButton4.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
-        synthChanButton8 = new Button (x + padding*2 + (w-padding*4)/3, y + padding*2 + 18, (w-padding*4)/3, 24, "8 chan", fontInfo.buttonLabel_size);
+        synthChanButton8 = new Button_obci (x + padding*2 + (w-padding*4)/3, y + padding*2 + 18, (w-padding*4)/3, 24, "8 chan", fontInfo.buttonLabel_size);
         if (nchan == 8) synthChanButton8.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
-        synthChanButton16 = new Button (x + padding*3 + ((w-padding*4)/3)*2, y + padding*2 + 18, (w-padding*4)/3, 24, "16 chan", fontInfo.buttonLabel_size);
+        synthChanButton16 = new Button_obci (x + padding*3 + ((w-padding*4)/3)*2, y + padding*2 + 18, (w-padding*4)/3, 24, "16 chan", fontInfo.buttonLabel_size);
         if (nchan == 16) synthChanButton16.setColorNotPressed(isSelected_color); //make it appear like this one is already selected
     }
 
@@ -2187,8 +2187,8 @@ class RecentPlaybackBox {
 
 class NovaXRBox {
     private int x, y, w, h, padding; //size and position
-    private Button novaXR250;
-    private Button novaXR500;
+    private Button_obci novaXR250;
+    private Button_obci novaXR500;
     private String boxLabel = "NOVAXR CONFIG";
     private String sampleRateLabel = "SAMPLE RATE";
     private ControlP5 novaXRcp5;
@@ -2203,10 +2203,10 @@ class NovaXRBox {
         novaXRcp5 = new ControlP5(ourApplet);
         novaXRcp5.setAutoDraw(false); //Setting this saves code as cp5 elements will only be drawn/visible when [cp5].draw() is called
 
-        novaXR250 = new Button (x + w - padding*2 - 60*2, y + 16 + padding*2, 60, 24, "250Hz", fontInfo.buttonLabel_size);
+        novaXR250 = new Button_obci (x + w - padding*2 - 60*2, y + 16 + padding*2, 60, 24, "250Hz", fontInfo.buttonLabel_size);
         novaXR250.setHelpText("Set Sampling Rate to 250Hz.");
         novaXR250.setColorNotPressed(isSelected_color);
-        novaXR500 = new Button (x + w - padding - 60, y + 16 + padding*2, 60, 24, "500Hz", fontInfo.buttonLabel_size);
+        novaXR500 = new Button_obci (x + w - padding - 60, y + 16 + padding*2, 60, 24, "500Hz", fontInfo.buttonLabel_size);
         novaXR500.setHelpText("Set Sampling Rate to 500Hz.");
         //x + padding, novaXR250.but_y + 24 + padding
         createDropdown("novaXR_Modes");
@@ -2321,11 +2321,11 @@ class PlaybackFileBox {
         h = 67;
         padding = _padding;
 
-        selectPlaybackFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT PLAYBACK FILE", fontInfo.buttonLabel_size);
+        selectPlaybackFile = new Button_obci (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT PLAYBACK FILE", fontInfo.buttonLabel_size);
         selectPlaybackFile.setHelpText("Click to open a dialog box to select an OpenBCI playback file (.txt or .csv).");
     
         // Sample data button
-        sampleDataButton = new Button(x + w - sampleDataButton_w - padding, y + padding - 2, sampleDataButton_w, sampleDataButton_h, "Sample Data", 14);
+        sampleDataButton = new Button_obci(x + w - sampleDataButton_w - padding, y + padding - 2, sampleDataButton_w, sampleDataButton_h, "Sample Data", 14);
         sampleDataButton.setCornerRoundess((int)(sampleDataButton_h));
         sampleDataButton.setFont(p4, 14);
         sampleDataButton.setColorNotPressed(color(57,128,204));
@@ -2490,12 +2490,12 @@ class RadioConfigBox {
         isShowing = false;
 
         //typical button height + 20 for larger autoscan button
-        autoscan = new Button(x + padding, y + padding + 18, w-(padding*2), 24 + 20, "AUTOSCAN", fontInfo.buttonLabel_size);
+        autoscan = new Button_obci(x + padding, y + padding + 18, w-(padding*2), 24 + 20, "AUTOSCAN", fontInfo.buttonLabel_size);
         //smaller buttons below autoscan
-        getChannel = new Button(x + padding, y + padding*3 + 18 + 24 + 44, (w-padding*3)/2, 24, "GET CHANNEL", fontInfo.buttonLabel_size);
-        systemStatus = new Button(x + padding, y + padding*2 + 18 + 44, (w-padding*3)/2, 24, "STATUS", fontInfo.buttonLabel_size);
-        setChannel = new Button(x + 2*padding + (w-padding*3)/2, y + padding*2 + 18 + 44, (w-padding*3)/2, 24, "CHANGE CHAN.", fontInfo.buttonLabel_size);
-        ovrChannel = new Button(x + 2*padding + (w-padding*3)/2, y + padding*3 + 18 + 24 + 44, (w-padding*3)/2, 24, "OVERRIDE DONGLE", fontInfo.buttonLabel_size);
+        getChannel = new Button_obci(x + padding, y + padding*3 + 18 + 24 + 44, (w-padding*3)/2, 24, "GET CHANNEL", fontInfo.buttonLabel_size);
+        systemStatus = new Button_obci(x + padding, y + padding*2 + 18 + 44, (w-padding*3)/2, 24, "STATUS", fontInfo.buttonLabel_size);
+        setChannel = new Button_obci(x + 2*padding + (w-padding*3)/2, y + padding*2 + 18 + 44, (w-padding*3)/2, 24, "CHANGE CHAN.", fontInfo.buttonLabel_size);
+        ovrChannel = new Button_obci(x + 2*padding + (w-padding*3)/2, y + padding*3 + 18 + 24 + 44, (w-padding*3)/2, 24, "OVERRIDE DONGLE", fontInfo.buttonLabel_size);
         
 
         //Set help text
@@ -2548,7 +2548,7 @@ class SDConverterBox {
         h = 67;
         padding = _padding;
 
-        selectSDFile = new Button (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT SD FILE", fontInfo.buttonLabel_size);
+        selectSDFile = new Button_obci (x + padding, y + padding*2 + 13, w - padding*2, 24, "SELECT SD FILE", fontInfo.buttonLabel_size);
         selectSDFile.setHelpText("Click here to select an SD file generated by Cyton or Cyton+Daisy and convert to plain text format.");
     }
 
@@ -2663,7 +2663,7 @@ class InitBox {
         h = 50;
         padding = _padding;
 
-        initSystemButton = new Button (padding, y + padding, w-padding*2, h - padding*2, "START SESSION", fontInfo.buttonLabel_size);
+        initSystemButton = new Button_obci (padding, y + padding, w-padding*2, h - padding*2, "START SESSION", fontInfo.buttonLabel_size);
     }
 
     public void update() {

--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -308,7 +308,7 @@ synchronized void mouseReleased() {
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-class Button {
+class Button_obci {
 
     int but_x, but_y, but_dx, but_dy;      // Position of square button
     //int rectSize = 90;     // Diameter of rect
@@ -339,13 +339,13 @@ class Button {
     boolean hasbgImage = false;
     private boolean ignoreHover = false;
 
-    public Button(int x, int y, int w, int h, String txt) {
+    public Button_obci(int x, int y, int w, int h, String txt) {
         setup(x, y, w, h, txt);
         buttonFont = p5;
         buttonTextSize = 12;
     }
 
-    public Button(int x, int y, int w, int h, String txt, int fontSize) {
+    public Button_obci(int x, int y, int w, int h, String txt, int fontSize) {
         setup(x, y, w, h, txt);
         buttonFont = p5;
         buttonTextSize = 12;
@@ -404,7 +404,7 @@ class Button {
 
     public void setString(String txt) {
         but_txt = txt;
-        //println("Button: setString: string = " + txt);
+        //println("Button_obci: setString: string = " + txt);
     }
 
     public void setHelpText(String _helpText){

--- a/OpenBCI_GUI/SoftwareSettings.pde
+++ b/OpenBCI_GUI/SoftwareSettings.pde
@@ -241,19 +241,19 @@ class SoftwareSettings {
     String nwOscIp1Load;  String nwOscIp2Load;  String nwOscIp3Load;  String nwOscIp4Load;
     String nwOscPort1Load;  String nwOscPort2Load;  String nwOscPort3Load;  String nwOscPort4Load;
     String nwOscAddress1Load;  String nwOscAddress2Load; String nwOscAddress3Load; String nwOscAddress4Load;
-    int nwOscFilter1Load;  int nwOscFilter2Load;  int nwOscFilter3Load;  int nwOscFilter4Load;
+    boolean nwOscFilter1Load, nwOscFilter2Load, nwOscFilter3Load, nwOscFilter4Load;
     //UDP load variables
     String nwUdpIp1Load;  String nwUdpIp2Load;  String nwUdpIp3Load;
     String nwUdpPort1Load;  String nwUdpPort2Load;  String nwUdpPort3Load;
-    int nwUdpFilter1Load;  int nwUdpFilter2Load;  int nwUdpFilter3Load;
+    boolean nwUdpFilter1Load, nwUdpFilter2Load, nwUdpFilter3Load;
     //LSL load variables
     String nwLSLName1Load;  String nwLSLName2Load;  String nwLSLName3Load;
     String nwLSLType1Load;  String nwLSLType2Load;  String nwLSLType3Load;
-    String nwLSLNumChan1Load;  String nwLSLNumChan2Load; String nwLSLNumChan3Load;
-    int nwLSLFilter1Load;  int nwLSLFilter2Load;  int nwLSLFilter3Load;
+    boolean nwLSLFilter1Load, nwLSLFilter2Load, nwLSLFilter3Load;
     //Serial load variables
     int nwSerialBaudRateLoad;
-    int nwSerialFilter1Load;
+    boolean nwSerialFilter1Load;
+
     //Primary JSON objects for saving and loading data
     private JSONObject saveSettingsJSONData;
     private JSONObject loadSettingsJSONData;
@@ -457,7 +457,7 @@ class SoftwareSettings {
                     saveNetworkingSettings.setString("OSC_ip"+i, (String) w_networking.getCP5Map().get("OSC_ip"+i));
                     saveNetworkingSettings.setString("OSC_port"+i, (String) w_networking.getCP5Map().get("OSC_port"+i));
                     saveNetworkingSettings.setString("OSC_address"+i, (String) w_networking.getCP5Map().get("OSC_address"+i));
-                    saveNetworkingSettings.setInt("OSC_filter"+i, (Integer) w_networking.getCP5Map().get("filter"+i));
+                    saveNetworkingSettings.setBoolean("OSC_filter"+i, (boolean) w_networking.getCP5Map().get("filter"+i));
                 }
                 break;
             case 2:
@@ -465,7 +465,7 @@ class SoftwareSettings {
                     saveNetworkingSettings.setInt("UDP_DataType"+i, (Integer) w_networking.getCP5Map().get(w_networking.datatypeNames[i-1]));
                     saveNetworkingSettings.setString("UDP_ip"+i, (String) w_networking.getCP5Map().get("UDP_ip"+i));
                     saveNetworkingSettings.setString("UDP_port"+i, (String) w_networking.getCP5Map().get("UDP_port"+i));
-                    saveNetworkingSettings.setInt("UDP_filter"+i, (Integer) w_networking.getCP5Map().get("filter"+i));
+                    saveNetworkingSettings.setBoolean("UDP_filter"+i, (boolean) w_networking.getCP5Map().get("filter"+i));
                 }
                 break;
             case 1:
@@ -473,14 +473,13 @@ class SoftwareSettings {
                     saveNetworkingSettings.setInt("LSL_DataType"+i, (Integer) w_networking.getCP5Map().get(w_networking.datatypeNames[i-1]));
                     saveNetworkingSettings.setString("LSL_name"+i, (String) w_networking.getCP5Map().get("LSL_name"+i));
                     saveNetworkingSettings.setString("LSL_type"+i, (String) w_networking.getCP5Map().get("LSL_type"+i));
-                    saveNetworkingSettings.setString("LSL_numchan"+i, (String) w_networking.getCP5Map().get("LSL_numchan"+i));
-                    saveNetworkingSettings.setInt("LSL_filter"+i, (Integer) w_networking.getCP5Map().get("filter"+i));
+                    saveNetworkingSettings.setBoolean("LSL_filter"+i, (boolean) w_networking.getCP5Map().get("filter"+i));
                 }
                 break;
             case 0:
                 saveNetworkingSettings.setInt("Serial_DataType1", (Integer) w_networking.getCP5Map().get("dataType1"));
                 saveNetworkingSettings.setInt("Serial_baudrate", (Integer) w_networking.getCP5Map().get("baud_rate"));
-                saveNetworkingSettings.setInt("Serial_filter1", (Integer) w_networking.getCP5Map().get("filter1"));
+                saveNetworkingSettings.setBoolean("Serial_filter1", (boolean) w_networking.getCP5Map().get("filter1"));
                 saveNetworkingSettings.setString("Serial_portName", (String) w_networking.getCP5Map().get("port_name"));
                 break;
         }//end of networking proctocol switch
@@ -665,10 +664,10 @@ class SoftwareSettings {
                 nwOscAddress2Load = loadNetworkingSettings.getString("OSC_address2");
                 nwOscAddress3Load = loadNetworkingSettings.getString("OSC_address3");
                 nwOscAddress4Load = loadNetworkingSettings.getString("OSC_address4");
-                nwOscFilter1Load = loadNetworkingSettings.getInt("OSC_filter1");
-                nwOscFilter2Load = loadNetworkingSettings.getInt("OSC_filter2");
-                nwOscFilter3Load = loadNetworkingSettings.getInt("OSC_filter3");
-                nwOscFilter4Load = loadNetworkingSettings.getInt("OSC_filter4");
+                nwOscFilter1Load = loadNetworkingSettings.getBoolean("OSC_filter1");
+                nwOscFilter2Load = loadNetworkingSettings.getBoolean("OSC_filter2");
+                nwOscFilter3Load = loadNetworkingSettings.getBoolean("OSC_filter3");
+                nwOscFilter4Load = loadNetworkingSettings.getBoolean("OSC_filter4");
                 break;
             case 2:
                 nwDataType1 = loadNetworkingSettings.getInt("UDP_DataType1");
@@ -680,9 +679,9 @@ class SoftwareSettings {
                 nwUdpPort1Load = loadNetworkingSettings.getString("UDP_port1");
                 nwUdpPort2Load = loadNetworkingSettings.getString("UDP_port2");
                 nwUdpPort3Load = loadNetworkingSettings.getString("UDP_port3");
-                nwUdpFilter1Load = loadNetworkingSettings.getInt("UDP_filter1");
-                nwUdpFilter2Load = loadNetworkingSettings.getInt("UDP_filter2");
-                nwUdpFilter3Load = loadNetworkingSettings.getInt("UDP_filter3");
+                nwUdpFilter1Load = loadNetworkingSettings.getBoolean("UDP_filter1");
+                nwUdpFilter2Load = loadNetworkingSettings.getBoolean("UDP_filter2");
+                nwUdpFilter3Load = loadNetworkingSettings.getBoolean("UDP_filter3");
                 break;
             case 1:
                 nwDataType1 = loadNetworkingSettings.getInt("LSL_DataType1");
@@ -694,17 +693,14 @@ class SoftwareSettings {
                 nwLSLType1Load = loadNetworkingSettings.getString("LSL_type1");
                 nwLSLType2Load = loadNetworkingSettings.getString("LSL_type2");
                 nwLSLType3Load = loadNetworkingSettings.getString("LSL_type3");
-                nwLSLNumChan1Load = loadNetworkingSettings.getString("LSL_numchan1");
-                nwLSLNumChan2Load = loadNetworkingSettings.getString("LSL_numchan2");
-                nwLSLNumChan3Load = loadNetworkingSettings.getString("LSL_numchan3");
-                nwLSLFilter1Load = loadNetworkingSettings.getInt("LSL_filter1");
-                nwLSLFilter2Load = loadNetworkingSettings.getInt("LSL_filter2");
-                nwLSLFilter3Load = loadNetworkingSettings.getInt("LSL_filter3");
+                nwLSLFilter1Load = loadNetworkingSettings.getBoolean("LSL_filter1");
+                nwLSLFilter2Load = loadNetworkingSettings.getBoolean("LSL_filter2");
+                nwLSLFilter3Load = loadNetworkingSettings.getBoolean("LSL_filter3");
                 break;
             case 0:
                 nwDataType1 = loadNetworkingSettings.getInt("Serial_DataType1");
                 nwSerialBaudRateLoad = loadNetworkingSettings.getInt("Serial_baudrate");
-                nwSerialFilter1Load = loadNetworkingSettings.getInt("Serial_filter1");
+                nwSerialFilter1Load = loadNetworkingSettings.getBoolean("Serial_filter1");
                 nwSerialPort = loadNetworkingSettings.getString("Serial_portName");
                 break;
         } //end switch case for all networking types
@@ -950,6 +946,10 @@ class SoftwareSettings {
         Protocol(nwProtocolLoad);
         //Update dropdowns and textfields in the Networking widget with loaded values
         w_networking.cp5_widget.getController("Protocol").getCaptionLabel().setText(nwProtocolArray[nwProtocolLoad]); //Reference the dropdown from the appropriate widget
+        w_networking.cp5_networking.get(RadioButton.class, "filter1").deactivateAll();
+        w_networking.cp5_networking.get(RadioButton.class, "filter2").deactivateAll();
+        w_networking.cp5_networking.get(RadioButton.class, "filter3").deactivateAll();
+        w_networking.cp5_networking.get(RadioButton.class, "filter4").deactivateAll();
         switch (nwProtocolLoad) {
             case 3:  //Apply OSC if loaded
                 println("Apply OSC Networking Mode");
@@ -973,10 +973,10 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address2").setText(nwOscAddress2Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address3").setText(nwOscAddress3Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address4").setText(nwOscAddress4Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(nwOscFilter1Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(nwOscFilter2Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(nwOscFilter3Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter4").activate(nwOscFilter4Load);
+                if (nwOscFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
+                if (nwOscFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
+                if (nwOscFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
+                if (nwOscFilter4Load) w_networking.cp5_networking.get(RadioButton.class, "filter4").activate(0);
                 break;
             case 2:  //Apply UDP if loaded
                 println("Apply UDP Networking Mode");
@@ -992,9 +992,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port1").setText(nwUdpPort1Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port2").setText(nwUdpPort2Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port3").setText(nwUdpPort3Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(nwUdpFilter1Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(nwUdpFilter2Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(nwUdpFilter3Load);
+                if (nwUdpFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
+                if (nwUdpFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
+                if (nwUdpFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
                 break;
             case 1:  //Apply LSL if loaded
                 println("Apply LSL Networking Mode");
@@ -1010,12 +1010,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type1").setText(nwLSLType1Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type2").setText(nwLSLType2Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type3").setText(nwLSLType3Load);
-                w_networking.cp5_networking.get(Textfield.class, "LSL_numchan1").setText(nwLSLNumChan1Load);
-                w_networking.cp5_networking.get(Textfield.class, "LSL_numchan2").setText(nwLSLNumChan2Load);
-                w_networking.cp5_networking.get(Textfield.class, "LSL_numchan3").setText(nwLSLNumChan3Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(nwLSLFilter1Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(nwLSLFilter2Load);
-                w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(nwLSLFilter3Load);
+                if (nwLSLFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
+                if (nwLSLFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
+                if (nwLSLFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
                 break;
             case 0:  //Apply Serial if loaded
                 println("Apply Serial Networking Mode");
@@ -1023,7 +1020,7 @@ class SoftwareSettings {
                 w_networking.cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setValue(nwDataType1); //Set value in backend
                 w_networking.cp5_networking_baudRate.getController("baud_rate").getCaptionLabel().setText(nwBaudRatesArray[nwSerialBaudRateLoad]); //Set text
                 w_networking.cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setValue(nwSerialBaudRateLoad); //Set value in backend
-                w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(nwSerialFilter1Load);
+                if (nwSerialFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
 
                 //Look for the portName in the dropdown list
                 int listSize = w_networking.cp5_networking_portName.get(ScrollableList.class, "port_name").getItems().size();

--- a/OpenBCI_GUI/SoftwareSettings.pde
+++ b/OpenBCI_GUI/SoftwareSettings.pde
@@ -946,10 +946,10 @@ class SoftwareSettings {
         Protocol(nwProtocolLoad);
         //Update dropdowns and textfields in the Networking widget with loaded values
         w_networking.cp5_widget.getController("Protocol").getCaptionLabel().setText(nwProtocolArray[nwProtocolLoad]); //Reference the dropdown from the appropriate widget
-        w_networking.cp5_networking.get(RadioButton.class, "filter1").deactivateAll();
-        w_networking.cp5_networking.get(RadioButton.class, "filter2").deactivateAll();
-        w_networking.cp5_networking.get(RadioButton.class, "filter3").deactivateAll();
-        w_networking.cp5_networking.get(RadioButton.class, "filter4").deactivateAll();
+        w_networking.cp5_networking.get(Button.class, "filter1").setSwitch(false);
+        w_networking.cp5_networking.get(Button.class, "filter2").setOff();
+        w_networking.cp5_networking.get(Button.class, "filter3").setOff();
+        w_networking.cp5_networking.get(Button.class, "filter4").setOff();
         switch (nwProtocolLoad) {
             case 3:  //Apply OSC if loaded
                 println("Apply OSC Networking Mode");
@@ -973,10 +973,10 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address2").setText(nwOscAddress2Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address3").setText(nwOscAddress3Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address4").setText(nwOscAddress4Load);
-                if (nwOscFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
-                if (nwOscFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
-                if (nwOscFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
-                if (nwOscFilter4Load) w_networking.cp5_networking.get(RadioButton.class, "filter4").activate(0);
+                if (nwOscFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
+                if (nwOscFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
+                if (nwOscFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
+                if (nwOscFilter4Load) w_networking.cp5_networking.get(Button.class, "filter4").setOn();
                 break;
             case 2:  //Apply UDP if loaded
                 println("Apply UDP Networking Mode");
@@ -992,9 +992,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port1").setText(nwUdpPort1Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port2").setText(nwUdpPort2Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port3").setText(nwUdpPort3Load);
-                if (nwUdpFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
-                if (nwUdpFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
-                if (nwUdpFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
+                if (nwUdpFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
+                if (nwUdpFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
+                if (nwUdpFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
                 break;
             case 1:  //Apply LSL if loaded
                 println("Apply LSL Networking Mode");
@@ -1010,9 +1010,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type1").setText(nwLSLType1Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type2").setText(nwLSLType2Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type3").setText(nwLSLType3Load);
-                if (nwLSLFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
-                if (nwLSLFilter2Load) w_networking.cp5_networking.get(RadioButton.class, "filter2").activate(0);
-                if (nwLSLFilter3Load) w_networking.cp5_networking.get(RadioButton.class, "filter3").activate(0);
+                if (nwLSLFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
+                if (nwLSLFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
+                if (nwLSLFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
                 break;
             case 0:  //Apply Serial if loaded
                 println("Apply Serial Networking Mode");
@@ -1020,7 +1020,7 @@ class SoftwareSettings {
                 w_networking.cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setValue(nwDataType1); //Set value in backend
                 w_networking.cp5_networking_baudRate.getController("baud_rate").getCaptionLabel().setText(nwBaudRatesArray[nwSerialBaudRateLoad]); //Set text
                 w_networking.cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setValue(nwSerialBaudRateLoad); //Set value in backend
-                if (nwSerialFilter1Load) w_networking.cp5_networking.get(RadioButton.class, "filter1").activate(0);
+                if (nwSerialFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
 
                 //Look for the portName in the dropdown list
                 int listSize = w_networking.cp5_networking_portName.get(ScrollableList.class, "port_name").getItems().size();

--- a/OpenBCI_GUI/SoftwareSettings.pde
+++ b/OpenBCI_GUI/SoftwareSettings.pde
@@ -946,10 +946,10 @@ class SoftwareSettings {
         Protocol(nwProtocolLoad);
         //Update dropdowns and textfields in the Networking widget with loaded values
         w_networking.cp5_widget.getController("Protocol").getCaptionLabel().setText(nwProtocolArray[nwProtocolLoad]); //Reference the dropdown from the appropriate widget
-        w_networking.cp5_networking.get(Button.class, "filter1").setSwitch(false);
-        w_networking.cp5_networking.get(Button.class, "filter2").setOff();
-        w_networking.cp5_networking.get(Button.class, "filter3").setOff();
-        w_networking.cp5_networking.get(Button.class, "filter4").setOff();
+        w_networking.cp5_networking.get(Toggle.class, "filter1").setState(false);
+        w_networking.cp5_networking.get(Toggle.class, "filter2").setState(false);
+        w_networking.cp5_networking.get(Toggle.class, "filter3").setState(false);
+        w_networking.cp5_networking.get(Toggle.class, "filter4").setState(false);
         switch (nwProtocolLoad) {
             case 3:  //Apply OSC if loaded
                 println("Apply OSC Networking Mode");
@@ -973,10 +973,10 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address2").setText(nwOscAddress2Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address3").setText(nwOscAddress3Load);
                 w_networking.cp5_networking.get(Textfield.class, "OSC_address4").setText(nwOscAddress4Load);
-                if (nwOscFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
-                if (nwOscFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
-                if (nwOscFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
-                if (nwOscFilter4Load) w_networking.cp5_networking.get(Button.class, "filter4").setOn();
+                w_networking.cp5_networking.get(Toggle.class, "filter1").setState(nwOscFilter1Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter2").setState(nwOscFilter2Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter3").setState(nwOscFilter3Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter4").setState(nwOscFilter4Load);
                 break;
             case 2:  //Apply UDP if loaded
                 println("Apply UDP Networking Mode");
@@ -992,9 +992,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port1").setText(nwUdpPort1Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port2").setText(nwUdpPort2Load);
                 w_networking.cp5_networking.get(Textfield.class, "UDP_port3").setText(nwUdpPort3Load);
-                if (nwUdpFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
-                if (nwUdpFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
-                if (nwUdpFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
+                w_networking.cp5_networking.get(Toggle.class, "filter1").setState(nwUdpFilter1Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter2").setState(nwUdpFilter2Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter3").setState(nwUdpFilter3Load);
                 break;
             case 1:  //Apply LSL if loaded
                 println("Apply LSL Networking Mode");
@@ -1010,9 +1010,9 @@ class SoftwareSettings {
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type1").setText(nwLSLType1Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type2").setText(nwLSLType2Load);
                 w_networking.cp5_networking.get(Textfield.class, "LSL_type3").setText(nwLSLType3Load);
-                if (nwLSLFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
-                if (nwLSLFilter2Load) w_networking.cp5_networking.get(Button.class, "filter2").setOn();
-                if (nwLSLFilter3Load) w_networking.cp5_networking.get(Button.class, "filter3").setOn();
+                w_networking.cp5_networking.get(Toggle.class, "filter1").setState(nwLSLFilter1Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter2").setState(nwLSLFilter2Load);
+                w_networking.cp5_networking.get(Toggle.class, "filter3").setState(nwLSLFilter3Load);
                 break;
             case 0:  //Apply Serial if loaded
                 println("Apply Serial Networking Mode");
@@ -1020,7 +1020,7 @@ class SoftwareSettings {
                 w_networking.cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setValue(nwDataType1); //Set value in backend
                 w_networking.cp5_networking_baudRate.getController("baud_rate").getCaptionLabel().setText(nwBaudRatesArray[nwSerialBaudRateLoad]); //Set text
                 w_networking.cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setValue(nwSerialBaudRateLoad); //Set value in backend
-                if (nwSerialFilter1Load) w_networking.cp5_networking.get(Button.class, "filter1").setOn();
+                w_networking.cp5_networking.get(Toggle.class, "filter1").setState(nwSerialFilter1Load);
 
                 //Look for the portName in the dropdown list
                 int listSize = w_networking.cp5_networking_portName.get(ScrollableList.class, "port_name").getItems().size();

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -16,21 +16,21 @@ TopNav topNav;
 
 class TopNav {
 
-    Button controlPanelCollapser;
-    Button fpsButton;
-    Button debugButton;
+    Button_obci controlPanelCollapser;
+    Button_obci fpsButton;
+    Button_obci debugButton;
 
-    Button stopButton;
+    Button_obci stopButton;
 
-    Button filtBPButton;
-    Button filtNotchButton;
+    Button_obci filtBPButton;
+    Button_obci filtNotchButton;
 
-    Button tutorialsButton;
-    Button shopButton;
-    Button issuesButton;
-    Button updateGuiVersionButton;
-    Button layoutButton;
-    Button configButton;
+    Button_obci tutorialsButton;
+    Button_obci shopButton;
+    Button_obci issuesButton;
+    Button_obci updateGuiVersionButton;
+    Button_obci layoutButton;
+    Button_obci configButton;
 
     LayoutSelector layoutSelector;
     TutorialSelector tutorialSelector;
@@ -46,12 +46,12 @@ class TopNav {
     //constructor
     TopNav() {
         int w = 256;
-        controlPanelCollapser = new Button(3, 3, w, 26, "System Control Panel", fontInfo.buttonLabel_size);
+        controlPanelCollapser = new Button_obci(3, 3, w, 26, "System Control Panel", fontInfo.buttonLabel_size);
         controlPanelCollapser.setFont(h3, 16);
         controlPanelCollapser.setIsActive(true);
         controlPanelCollapser.isDropdownButton = true;
 
-        fpsButton = new Button(controlPanelCollapser.but_x + controlPanelCollapser.but_dx + 3, 3, 73, 26, "XX" + " fps", fontInfo.buttonLabel_size);
+        fpsButton = new Button_obci(controlPanelCollapser.but_x + controlPanelCollapser.but_dx + 3, 3, 73, 26, "XX" + " fps", fontInfo.buttonLabel_size);
         if (frameRateCounter==0) {
             fpsButton.setString("24 fps");
         }
@@ -67,33 +67,33 @@ class TopNav {
 
         fpsButton.setFont(h3, 16);
         fpsButton.setHelpText("If you're having latency issues, try adjusting the frame rate and see if it helps!");
-        //highRezButton = new Button(3+3+w+73+3, 3, 26, 26, "XX", fontInfo.buttonLabel_size);
+        //highRezButton = new Button_obci(3+3+w+73+3, 3, 26, 26, "XX", fontInfo.buttonLabel_size);
         controlPanelCollapser.setFont(h3, 16);
 
         //top right buttons from right to left
-        debugButton = new Button(width - 33 - 3, 3, 33, 26, " ", fontInfo.buttonLabel_size);
+        debugButton = new Button_obci(width - 33 - 3, 3, 33, 26, " ", fontInfo.buttonLabel_size);
         debugButton.setHelpText("Click to open the Console Log window.");
 
-        tutorialsButton = new Button(debugButton.but_x - 80 - 3, 3, 80, 26, "Help", fontInfo.buttonLabel_size);
+        tutorialsButton = new Button_obci(debugButton.but_x - 80 - 3, 3, 80, 26, "Help", fontInfo.buttonLabel_size);
         tutorialsButton.setFont(h3, 16);
         tutorialsButton.setHelpText("Click to find links to helpful online tutorials and getting started guides. Also, check out how to create custom widgets for the GUI!");
 
-        issuesButton = new Button(tutorialsButton.but_x - 80 - 3, 3, 80, 26, "Issues", fontInfo.buttonLabel_size);
+        issuesButton = new Button_obci(tutorialsButton.but_x - 80 - 3, 3, 80, 26, "Issues", fontInfo.buttonLabel_size);
         issuesButton.setHelpText("If you have suggestions or want to share a bug you've found, please create an issue on the GUI's Github repo!");
         issuesButton.setURL("https://github.com/OpenBCI/OpenBCI_GUI/issues");
         issuesButton.setFont(h3, 16);
 
-        shopButton = new Button(issuesButton.but_x - 80 - 3, 3, 80, 26, "Shop", fontInfo.buttonLabel_size);
+        shopButton = new Button_obci(issuesButton.but_x - 80 - 3, 3, 80, 26, "Shop", fontInfo.buttonLabel_size);
         shopButton.setHelpText("Head to our online store to purchase the latest OpenBCI hardware and accessories.");
         shopButton.setURL("http://shop.openbci.com/");
         shopButton.setFont(h3, 16);
 
-        configButton = new Button(width - 70 - 3, 35, 70, 26, "Settings", fontInfo.buttonLabel_size);
+        configButton = new Button_obci(width - 70 - 3, 35, 70, 26, "Settings", fontInfo.buttonLabel_size);
         configButton.setHelpText("Save and Load GUI Settings! Click Default to revert to factory settings.");
         configButton.setFont(h4, 14);
 
         //Lookup and check the local GUI version against the latest Github release
-        updateGuiVersionButton = new Button(shopButton.but_x - 80 - 3, 3, 80, 26, "Update", fontInfo.buttonLabel_size);
+        updateGuiVersionButton = new Button_obci(shopButton.but_x - 80 - 3, 3, 80, 26, "Update", fontInfo.buttonLabel_size);
         updateGuiVersionButton.setFont(h3, 16);
         
         checkInternetFetchGithubData();
@@ -106,21 +106,21 @@ class TopNav {
     }
 
     void initSecondaryNav() {
-        stopButton = new Button(3, 35, 170, 26, stopButton_pressToStart_txt, fontInfo.buttonLabel_size);
+        stopButton = new Button_obci(3, 35, 170, 26, stopButton_pressToStart_txt, fontInfo.buttonLabel_size);
         stopButton.setFont(h4, 14);
         stopButton.setColorNotPressed(color(184, 220, 105));
         stopButton.setHelpText("Press this button to Stop/Start the data stream. Or press <SPACEBAR>");
 
-        filtNotchButton = new Button(7 + stopButton.but_dx, 35, 70, 26, "Notch\n" + dataProcessing.getShortNotchDescription(), fontInfo.buttonLabel_size);
+        filtNotchButton = new Button_obci(7 + stopButton.but_dx, 35, 70, 26, "Notch\n" + dataProcessing.getShortNotchDescription(), fontInfo.buttonLabel_size);
         filtNotchButton.setFont(p5, 12);
         filtNotchButton.setHelpText("Here you can adjust the Notch Filter that is applied to all \"Filtered\" data.");
 
-        filtBPButton = new Button(11 + stopButton.but_dx + 70, 35, 70, 26, "BP Filt\n" + dataProcessing.getShortFilterDescription(), fontInfo.buttonLabel_size);
+        filtBPButton = new Button_obci(11 + stopButton.but_dx + 70, 35, 70, 26, "BP Filt\n" + dataProcessing.getShortFilterDescription(), fontInfo.buttonLabel_size);
         filtBPButton.setFont(p5, 12);
         filtBPButton.setHelpText("Here you can adjust the Band Pass Filter that is applied to all \"Filtered\" data.");
 
         //right to left in top right (secondary nav)
-        layoutButton = new Button(width - 3 - 60, 35, 60, 26, "Layout", fontInfo.buttonLabel_size);
+        layoutButton = new Button_obci(width - 3 - 60, 35, 60, 26, "Layout", fontInfo.buttonLabel_size);
         layoutButton.setHelpText("Here you can alter the overall layout of the GUI, allowing for different container configurations with more or less widgets.");
         layoutButton.setFont(h4, 14);
 
@@ -573,7 +573,7 @@ class LayoutSelector {
     int x, y, w, h, margin, b_w, b_h;
     boolean isVisible;
 
-    ArrayList<Button> layoutOptions; //
+    ArrayList<Button_obci> layoutOptions; //
 
     LayoutSelector() {
         w = 180;
@@ -587,7 +587,7 @@ class LayoutSelector {
 
         isVisible = false;
 
-        layoutOptions = new ArrayList<Button>();
+        layoutOptions = new ArrayList<Button_obci>();
         addLayoutOptionButton();
     }
 
@@ -690,25 +690,25 @@ class LayoutSelector {
         //FIRST ROW
 
         //setup button 1 -- full screen
-        Button tempLayoutButton = new Button(x + margin, y + margin, b_w, b_h, "N/A");
+        Button_obci tempLayoutButton = new Button_obci(x + margin, y + margin, b_w, b_h, "N/A");
         PImage tempBackgroundImage = loadImage("layout_buttons/layout_1.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 2 -- 2x2
-        tempLayoutButton = new Button(x + 2*margin + b_w*1, y + margin, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 2*margin + b_w*1, y + margin, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_2.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 3 -- 2x1
-        tempLayoutButton = new Button(x + 3*margin + b_w*2, y + margin, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 3*margin + b_w*2, y + margin, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_3.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 4 -- 1x2
-        tempLayoutButton = new Button(x + 4*margin + b_w*3, y + margin, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 4*margin + b_w*3, y + margin, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_4.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
@@ -716,25 +716,25 @@ class LayoutSelector {
         //SECOND ROW
 
         //setup button 5
-        tempLayoutButton = new Button(x + margin, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + margin, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_5.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 6
-        tempLayoutButton = new Button(x + 2*margin + b_w*1, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 2*margin + b_w*1, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_6.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 7
-        tempLayoutButton = new Button(x + 3*margin + b_w*2, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 3*margin + b_w*2, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_7.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 8
-        tempLayoutButton = new Button(x + 4*margin + b_w*3, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 4*margin + b_w*3, y + 2*margin + 1*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_8.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
@@ -743,25 +743,25 @@ class LayoutSelector {
 
         h = margin*4 + b_h*3;
         //setup button 9
-        tempLayoutButton = new Button(x + margin, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + margin, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_9.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 10
-        tempLayoutButton = new Button(x + 2*margin + b_w*1, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 2*margin + b_w*1, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_10.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 11
-        tempLayoutButton = new Button(x + 3*margin + b_w*2, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 3*margin + b_w*2, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_11.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
 
         //setup button 12
-        tempLayoutButton = new Button(x + 4*margin + b_w*3, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
+        tempLayoutButton = new Button_obci(x + 4*margin + b_w*3, y + 3*margin + 2*b_h, b_w, b_h, "N/A");
         tempBackgroundImage = loadImage("layout_buttons/layout_12.png");
         tempLayoutButton.setBackgroundImage(tempBackgroundImage);
         layoutOptions.add(tempLayoutButton);
@@ -772,7 +772,7 @@ class ConfigSelector {
     int x, y, w, h, margin, b_w, b_h;
     boolean clearAllSettingsPressed;
     boolean isVisible;
-    ArrayList<Button> configOptions;
+    ArrayList<Button_obci> configOptions;
     int configHeight = 0;
     color newGreen = color(114,204,171);
     color expertPurple = color(135,95,154);
@@ -797,7 +797,7 @@ class ConfigSelector {
 
         isVisible = false;
 
-        configOptions = new ArrayList<Button>();
+        configOptions = new ArrayList<Button_obci>();
         addConfigButtons();
 
         buttonSpacer = (systemMode == SYSTEMMODE_POSTINIT) ? configOptions.size() : configOptions.size() - 4;
@@ -968,7 +968,7 @@ class ConfigSelector {
         //Customize initial button appearance here
         //setup button 0 -- Expert Mode Toggle Button
         int buttonNumber = 0;
-        Button tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Turn Expert Mode On");
+        Button_obci tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Turn Expert Mode On");
         tempConfigButton.setFont(p5, 12);
         tempConfigButton.setColorNotPressed(newGreen);
         tempConfigButton.setFontColorNotActive(color(255));
@@ -977,19 +977,19 @@ class ConfigSelector {
 
         //setup button 1 -- Save Custom Settings
         buttonNumber++;
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Save");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Save");
         tempConfigButton.setFont(p5, 12); 
         configOptions.add(tempConfigButton);
 
         //setup button 2 -- Load Custom Settings
         buttonNumber++;
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Load");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Load");
         tempConfigButton.setFont(p5, 12);
         configOptions.add(tempConfigButton);
 
         //setup button 3 -- Default Settings
         buttonNumber++;
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Default");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Default");
         tempConfigButton.setFont(p5, 12);
         configOptions.add(tempConfigButton);
 
@@ -997,7 +997,7 @@ class ConfigSelector {
         buttonNumber = 0;
         //Update the height of the Settings dropdown
         h = margin*(buttonNumber+1) + b_h*(buttonNumber+1);
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Clear All");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Clear All");
         tempConfigButton.setFont(p5, 12);
         tempConfigButton.setColorNotPressed(cautionRed);
         tempConfigButton.setFontColorNotActive(color(255));
@@ -1007,14 +1007,14 @@ class ConfigSelector {
         //setup button 5 -- Are You Sure? No
         buttonNumber++;
         //leave space for "Are You Sure?"
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber+1), b_w, b_h, "No");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber+1), b_w, b_h, "No");
         tempConfigButton.setFont(p5, 12);
         configOptions.add(tempConfigButton);
 
 
         //setup button 6 -- Are You Sure? Yes
         buttonNumber++;
-        tempConfigButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber+1), b_w, b_h, "Yes");
+        tempConfigButton = new Button_obci (x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber+1), b_w, b_h, "Yes");
         tempConfigButton.setFont(p5, 12);
         tempConfigButton.setHelpText("Clicking 'Yes' will delete all user settings and stop the session if running.");
         configOptions.add(tempConfigButton);
@@ -1053,7 +1053,7 @@ class TutorialSelector {
     int x, y, w, h, margin, b_w, b_h;
     boolean isVisible;
 
-    ArrayList<Button> tutorialOptions; //
+    ArrayList<Button_obci> tutorialOptions; //
 
     TutorialSelector() {
         w = 180;
@@ -1068,7 +1068,7 @@ class TutorialSelector {
 
         isVisible = false;
 
-        tutorialOptions = new ArrayList<Button>();
+        tutorialOptions = new ArrayList<Button_obci>();
         addTutorialButtons();
     }
 
@@ -1175,35 +1175,35 @@ class TutorialSelector {
 
         //setup button 1 -- full screen
         int buttonNumber = 0;
-        Button tempTutorialButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Getting Started");
+        Button_obci tempTutorialButton = new Button_obci(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Getting Started");
         tempTutorialButton.setFont(p5, 12);
         tempTutorialButton.setURL("https://openbci.github.io/Documentation/docs/01GettingStarted/GettingStartedLanding");
         tutorialOptions.add(tempTutorialButton);
 
         buttonNumber = 1;
         h = margin*(buttonNumber+2) + b_h*(buttonNumber+1);
-        tempTutorialButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Testing Impedance");
+        tempTutorialButton = new Button_obci(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Testing Impedance");
         tempTutorialButton.setFont(p5, 12);
         tempTutorialButton.setURL("https://openbci.github.io/Documentation/docs/06Software/01-OpenBCISoftware/GUIDocs#impedance-testing");
         tutorialOptions.add(tempTutorialButton);
 
         buttonNumber = 2;
         h = margin*(buttonNumber+2) + b_h*(buttonNumber+1);
-        tempTutorialButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Troubleshooting Guide");
+        tempTutorialButton = new Button_obci(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Troubleshooting Guide");
         tempTutorialButton.setFont(p5, 12);
         tempTutorialButton.setURL("https://docs.openbci.com/docs/10Troubleshooting/GUI_Troubleshooting");
         tutorialOptions.add(tempTutorialButton);
 
         buttonNumber = 3;
         h = margin*(buttonNumber+2) + b_h*(buttonNumber+1);
-        tempTutorialButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Building Custom Widgets");
+        tempTutorialButton = new Button_obci(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "Building Custom Widgets");
         tempTutorialButton.setFont(p5, 12);
         tempTutorialButton.setURL("https://openbci.github.io/Documentation/docs/06Software/01-OpenBCISoftware/GUIWidgets#custom-widget");
         tutorialOptions.add(tempTutorialButton);
 
         buttonNumber = 4;
         h = margin*(buttonNumber+2) + b_h*(buttonNumber+1);
-        tempTutorialButton = new Button(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "OpenBCI Forum");
+        tempTutorialButton = new Button_obci(x + margin, y + margin*(buttonNumber+1) + b_h*(buttonNumber), b_w, b_h, "OpenBCI Forum");
         tempTutorialButton.setFont(p5, 12);
         tempTutorialButton.setURL("https://openbci.com/forum/");
         tutorialOptions.add(tempTutorialButton);

--- a/OpenBCI_GUI/W_Accelerometer.pde
+++ b/OpenBCI_GUI/W_Accelerometer.pde
@@ -52,7 +52,7 @@ class W_Accelerometer extends Widget {
     private boolean visible = true;
     private boolean updating = true;
     boolean accelInitHasOccured = false;
-    private Button accelModeButton;
+    private Button_obci accelModeButton;
 
     private AccelerometerCapableBoard accelBoard;
 
@@ -79,7 +79,7 @@ class W_Accelerometer extends Widget {
         accelerometerBar = new AccelerometerBar(_parent, accelXyzLimit, accelGraphX, accelGraphY, accelGraphWidth, accelGraphHeight);
         accelerometerBar.adjustTimeAxis(w_timeSeries.xLimOptions[settings.tsHorizScaleSave]); //sync horiz axis to Time Series by default
 
-        accelModeButton = new Button((int)(x + 3), (int)(y + 3 - navHeight), 120, navHeight - 6, "", 12);
+        accelModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 120, navHeight - 6, "", 12);
         accelModeButton.setCornerRoundess((int)(navHeight-6));
         accelModeButton.setFont(p5,12);
         accelModeButton.setColorNotPressed(color(57,128,204));

--- a/OpenBCI_GUI/W_AnalogRead.pde
+++ b/OpenBCI_GUI/W_AnalogRead.pde
@@ -34,7 +34,7 @@ class W_AnalogRead extends Widget {
     private int arInitialVertScaleIndex = 5;
     private int arInitialHorizScaleIndex = 0;
 
-    Button analogModeButton;
+    Button_obci analogModeButton;
 
     private AnalogCapableBoard analogBoard;
 
@@ -84,7 +84,7 @@ class W_AnalogRead extends Widget {
             analogReadBars[i].adjustTimeAxis(w_timeSeries.xLimOptions[settings.tsHorizScaleSave]);
         }
 
-        analogModeButton = new Button((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
+        analogModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
         analogModeButton.setCornerRoundess((int)(navHeight-6));
         analogModeButton.setFont(p5,12);
         analogModeButton.setColorNotPressed(color(57,128,204));

--- a/OpenBCI_GUI/W_DigitalRead.pde
+++ b/OpenBCI_GUI/W_DigitalRead.pde
@@ -22,7 +22,7 @@ class W_DigitalRead extends Widget {
     private boolean visible = true;
     private boolean updating = true;
 
-    Button digitalModeButton;
+    Button_obci digitalModeButton;
 
     private DigitalCapableBoard digitalBoard;
 
@@ -78,7 +78,7 @@ class W_DigitalRead extends Widget {
             digitalReadDots[i] = tempDot;
         }
 
-        digitalModeButton = new Button((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "DIGITAL TOGGLE", 12);
+        digitalModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "DIGITAL TOGGLE", 12);
         digitalModeButton.setCornerRoundess((int)(navHeight-6));
         digitalModeButton.setFont(p5,12);
         digitalModeButton.setColorNotPressed(color(57,128,204));

--- a/OpenBCI_GUI/W_EMG.pde
+++ b/OpenBCI_GUI/W_EMG.pde
@@ -121,7 +121,7 @@ class W_emg extends Widget {
     boolean[] events;
     int currChannel;
     int theBaud;
-    Button connectButton;
+    Button_obci connectButton;
     Serial serialOutEMG;
     String theSerial;
 
@@ -245,7 +245,7 @@ class W_emg extends Widget {
 
         if (emgAdvanced) {
             if (connectButton != null) connectButton.draw();
-            else connectButton = new Button(int(x) + 2, int(y) - navHeight + 2, 100, navHeight - 6, "Connect", fontInfo.buttonLabel_size);
+            else connectButton = new Button_obci(int(x) + 2, int(y) - navHeight + 2, 100, navHeight - 6, "Connect", fontInfo.buttonLabel_size);
 
             stroke(1, 18, 41, 125);
 

--- a/OpenBCI_GUI/W_GanglionImpedance.pde
+++ b/OpenBCI_GUI/W_GanglionImpedance.pde
@@ -11,13 +11,13 @@
 ///////////////////////////////////////////////////,
 
 class W_GanglionImpedance extends Widget {
-    Button startStopCheck;
+    Button_obci startStopCheck;
     int padding = 24;
 
     W_GanglionImpedance(PApplet _parent){
         super(_parent); //calls the parent CONSTRUCTOR method of Widget (DON'T REMOVE)
 
-        startStopCheck = new Button (x + padding, y + padding, 200, navHeight, "Start Impedance Check", 12);
+        startStopCheck = new Button_obci (x + padding, y + padding, 200, navHeight, "Start Impedance Check", 12);
         startStopCheck.setFont(p4, 14);
     }
 

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -100,13 +100,13 @@ class W_Networking extends Widget {
         "127.0.0.1","12347",
         "127.0.0.1","12348"};
     String[] lslTextFieldNames = {
-        "LSL_name1","LSL_type1","LSL_numchan1",
-        "LSL_name2","LSL_type2","LSL_numchan2",
-        "LSL_name3","LSL_type3","LSL_numchan3"};
+        "LSL_name1","LSL_type1",
+        "LSL_name2","LSL_type2",
+        "LSL_name3","LSL_type3"};
     String[] lslTextDefaultVals = {
-        "obci_eeg1","EEG",Integer.toString(nchan),
-        "obci_eeg2","EEG",Integer.toString(nchan),
-        "obci_eeg3","EEG",Integer.toString(nchan)};
+        "obci_eeg1","EEG",
+        "obci_eeg2","EEG",
+        "obci_eeg3","EEG"};
     String networkingGuideURL = "https://openbci.github.io/Documentation/docs/06Software/01-OpenBCISoftware/GUIWidgets#networking";
     String dataOutputsURL = "https://docs.google.com/document/d/e/2PACX-1vR_4DXPTh1nuiOwWKwIZN3NkGP3kRwpP4Hu6fQmy3jRAOaydOuEI1jket6V4V6PG4yIG15H1N7oFfdV/pub";
     boolean configIsVisible = false;
@@ -170,7 +170,7 @@ class W_Networking extends Widget {
             cp5Map.put(datatypeNames[i], int(cp5_networking_dropdowns.get(ScrollableList.class, datatypeNames[i]).getValue()));
             //filter radio buttons
             String filterName = "filter" + (i+1);
-            cp5Map.put(filterName, int(cp5_networking.get(RadioButton.class, filterName).getValue()));
+            cp5Map.put(filterName, cp5_networking.get(RadioButton.class, filterName).getState(0));
         }
         //osc textfields
         copyCP5TextToMap(oscTextFieldNames, cp5Map);
@@ -353,8 +353,7 @@ class W_Networking extends Widget {
             textFont(h1,headerFontSize);
             text("Name", column0,row2);
             text("Type", column0,row3);
-            text("# Chan", column0, row4);
-            text("Filters",column0,row5);
+            text("Filters",column0,row4);
         } else if (protocolMode.equals("Serial")) {
             textFont(f4,40);
             text("Serial", x+20,y+h/8+15);
@@ -739,16 +738,13 @@ class W_Networking extends Widget {
             }
             cp5_networking.get(Textfield.class, "LSL_name1").setPosition(column1,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type1").setPosition(column1,row3 - offset);
-            cp5_networking.get(Textfield.class, "LSL_numchan1").setPosition(column1,row4 - offset);
             cp5_networking.get(Textfield.class, "LSL_name2").setPosition(column2,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type2").setPosition(column2,row3 - offset);
-            cp5_networking.get(Textfield.class, "LSL_numchan2").setPosition(column2,row4 - offset);
             cp5_networking.get(Textfield.class, "LSL_name3").setPosition(column3,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type3").setPosition(column3,row3 - offset);
-            cp5_networking.get(Textfield.class, "LSL_numchan3").setPosition(column3,row4 - offset);
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("Serial")) {
             //Serial Specific
             cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setPosition(column1, row2-offset);
@@ -867,7 +863,7 @@ class W_Networking extends Widget {
         String ip;
         int port;
         String address;
-        int filt_pos;
+        boolean filt_pos;
         String name;
         int nChanLSL;
         int baudRate;
@@ -885,7 +881,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port1").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address1").getText();
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter1").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
                 stream1 = new Stream(dt1, ip, port, address, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -894,7 +890,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port2").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address2").getText();
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter2").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
                 stream2 = new Stream(dt2, ip, port, address, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -903,7 +899,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port3").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address3").getText();
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter3").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
                 stream3 = new Stream(dt3, ip, port, address, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -912,7 +908,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip4").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port4").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address4").getText();
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter4").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter4").getState(0);
                 stream4 = new Stream(dt4, ip, port, address, filt_pos, nchan);
             } else {
                 stream4 = null;
@@ -923,7 +919,7 @@ class W_Networking extends Widget {
             if (!dt1.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port1").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter1").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
                 stream1 = new Stream(dt1, ip, port, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -931,7 +927,7 @@ class W_Networking extends Widget {
             if (!dt2.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port2").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter2").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
                 stream2 = new Stream(dt2, ip, port, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -939,7 +935,7 @@ class W_Networking extends Widget {
             if (!dt3.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port3").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter3").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
                 stream3 = new Stream(dt3, ip, port, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -947,11 +943,13 @@ class W_Networking extends Widget {
 
             // Establish LSL Streams
         } else if (protocolMode.equals("LSL")) {
+            
+
             if (!dt1.equals("None")) {
                 name = cp5_networking.get(Textfield.class, "LSL_name1").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type1").getText();
-                nChanLSL = Integer.parseInt(cp5_networking.get(Textfield.class, "LSL_numchan1").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter1").getValue();
+                nChanLSL = getDataTypeNumChanLSL(dt1);
+                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
                 stream1 = new Stream(dt1, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -959,8 +957,8 @@ class W_Networking extends Widget {
             if (!dt2.equals("None")) {
                 name = cp5_networking.get(Textfield.class, "LSL_name2").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type2").getText();
-                nChanLSL = Integer.parseInt(cp5_networking.get(Textfield.class, "LSL_numchan2").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter2").getValue();
+                nChanLSL = getDataTypeNumChanLSL(dt2);
+                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
                 stream2 = new Stream(dt2, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -968,22 +966,19 @@ class W_Networking extends Widget {
             if (!dt3.equals("None")) {
                 name = cp5_networking.get(Textfield.class, "LSL_name3").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type3").getText();
-                nChanLSL = Integer.parseInt(cp5_networking.get(Textfield.class, "LSL_numchan3").getText());
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter3").getValue();
+                nChanLSL = getDataTypeNumChanLSL(dt3);
+                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
                 stream3 = new Stream(dt3, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream3 = null;
             }
         } else if (protocolMode.equals("Serial")) {
-            // %%%%%
             if (!dt1.equals("None")) {
                 name = comPorts.get((int)(cp5_networking_portName.get(ScrollableList.class, "port_name").getValue()));
                 println("ComPort: " + name);
-                // name = cp5_networking_portName.get(ScrollableList.class, "port_name").getItem((int)cp5_networking_portName.get(ScrollableList.class, "port_name").getValue());
                 println("Baudrate: " + Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue()))));
                 baudRate = Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue())));
-
-                filt_pos = (int)cp5_networking.get(RadioButton.class, "filter1").getValue();
+                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
                 stream1 = new Stream(dt1, name, baudRate, filt_pos, pApplet, nchan);  //String dataType, String portName, int baudRate, int filter, PApplet _this
             } else {
                 stream1 = null;
@@ -1027,6 +1022,42 @@ class W_Networking extends Widget {
             stream4.quit();
             stream4=null;
         }
+    }
+
+    //Fix #644 - Remove confusing #Chan textfield from Networking Widget and account for this here
+    private int getDataTypeNumChanLSL(String dataType) {
+        if (dataType.equals("TimeSeries")) {
+            return currentBoard.getNumEXGChannels();
+        } else if (dataType.equals("FFT")) {
+            return 125;
+        } else if (dataType.equals("EMG")) {
+            return currentBoard.getNumEXGChannels();
+        } else if (dataType.equals("BandPower")) {
+            return 5;
+         } else if (dataType.equals("Pulse")) {
+            return 3;
+        } else if (dataType.equals("Accel/Aux")) {
+            if (currentBoard instanceof AccelerometerCapableBoard) {
+                AccelerometerCapableBoard accelBoard = (AccelerometerCapableBoard)currentBoard;
+                if (accelBoard.isAccelerometerActive()) {
+                    return accelBoard.getAccelerometerChannels().length;
+                }
+            }
+            if (currentBoard instanceof AnalogCapableBoard) {
+                AnalogCapableBoard analogBoard = (AnalogCapableBoard)currentBoard;
+                if (analogBoard.isAnalogActive()) {
+                    return analogBoard.getAnalogChannels().length;
+                }
+            }
+            if (currentBoard instanceof DigitalCapableBoard) {
+                DigitalCapableBoard digitalBoard = (DigitalCapableBoard)currentBoard;
+                if (digitalBoard.isDigitalActive()) {
+                    return digitalBoard.getDigitalChannels().length;
+                }
+            }
+        }
+        outputError("Error detecting numChan for LSL stream... please fix!");
+        return 0;
     }
 
     void clearCP5() {
@@ -1157,7 +1188,7 @@ class Stream extends Thread {
     String ip;
     int port;
     String address;
-    int filter;
+    boolean filter;
     String streamType;
     String streamName;
     int nChanLSL;
@@ -1204,7 +1235,7 @@ class Stream extends Thread {
     }
 
     /* OSC Stream */
-    Stream(String dataType, String ip, int port, String address, int filter, int _nchan) {
+    Stream(String dataType, String ip, int port, String address, boolean filter, int _nchan) {
         this.protocol = "OSC";
         this.dataType = dataType;
         this.ip = ip;
@@ -1219,7 +1250,7 @@ class Stream extends Thread {
         }
     }
     /*UDP Stream */
-    Stream(String dataType, String ip, int port, int filter, int _nchan) {
+    Stream(String dataType, String ip, int port, boolean filter, int _nchan) {
         this.protocol = "UDP";
         this.dataType = dataType;
         this.ip = ip;
@@ -1238,7 +1269,7 @@ class Stream extends Thread {
         }
     }
     /* LSL Stream */
-    Stream(String dataType, String streamName, String streamType, int nChanLSL, int filter, int _nchan) {
+    Stream(String dataType, String streamName, String streamType, int nChanLSL, boolean filter, int _nchan) {
         this.protocol = "LSL";
         this.dataType = dataType;
         this.streamName = streamName;
@@ -1254,7 +1285,7 @@ class Stream extends Thread {
     }
 
     // Serial Stream %%%%%
-    Stream(String dataType, String portName, int baudRate, int filter, PApplet _this, int _nchan) {
+    Stream(String dataType, String portName, int baudRate, boolean filter, PApplet _this, int _nchan) {
         // %%%%%
         this.protocol = "Serial";
         this.dataType = dataType;
@@ -1319,7 +1350,6 @@ class Stream extends Thread {
             } else {
                 if (checkForData()) {
                     sendData();
-                    //setDataFalse(); //Wait until all streams are done, Fixes 592
                 }
             }
         }
@@ -1395,7 +1425,7 @@ class Stream extends Thread {
     void sendTimeSeriesData() {
 
         // TIME SERIES UNFILTERED
-        if (filter==0) {
+        if (this.filter==false) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i=0;i<nPointsPerUpdate;i++) {
@@ -1461,7 +1491,7 @@ class Stream extends Thread {
 
 
         // TIME SERIES FILTERED
-        } else if (filter==1) {
+        } else {
             if (this.protocol.equals("OSC")) {
                 for (int i=0;i<nPointsPerUpdate;i++) {
                     msg.clearArguments();
@@ -1527,7 +1557,7 @@ class Stream extends Thread {
         //EEG/FFT readings above 125Hz don't typically travel through the skull
         //So for now, only send out 0-125Hz with 1 bin per Hz
         //Bin 10 == 10Hz frequency range
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i=0;i<numChan;i++) {
@@ -1605,7 +1635,7 @@ class Stream extends Thread {
         // UNFILTERED & FILTERED ... influenced globally by the FFT filters dropdown ... just like the FFT data
         int numBandPower = 5; //DELTA, THETA, ALPHA, BETA, GAMMA
 
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i=0;i<numChan;i++) {
@@ -1644,7 +1674,7 @@ class Stream extends Thread {
                 }
                 // LSL
             } else if (this.protocol.equals("LSL")) {
-
+                // DELTA, THETA, ALPHA, BETA, GAMMA
                 float[] avgPowerLSL = new float[numChan*numBandPower];
                 for (int i=0; i<numChan;i++) {
                     for (int j=0;j<numBandPower;j++) {
@@ -1678,7 +1708,7 @@ class Stream extends Thread {
 
     void sendEMGData() {
         // UNFILTERED & FILTERED ... influenced globally by the FFT filters dropdown ... just like the FFT data
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i=0;i<numChan;i++) {
@@ -1711,13 +1741,11 @@ class Stream extends Thread {
                 }
                 // LSL
             } else if (this.protocol.equals("LSL")) {
-                if (filter==0) {
-                    for (int j=0;j<numChan;j++) {
-                        dataToSend[j] = w_emg.motorWidgets[j].output_normalized;
-                    }
-                    // Add timestamp to LSL Stream
-                    outlet_data.push_sample(dataToSend, System.currentTimeMillis());
+                for (int j=0;j<numChan;j++) {
+                    dataToSend[j] = w_emg.motorWidgets[j].output_normalized;
                 }
+                // Add timestamp to LSL Stream
+                outlet_data.push_sample(dataToSend, System.currentTimeMillis());
             } else if (this.protocol.equals("Serial")) {     // Send NORMALIZED EMG CHANNEL Data over Serial ... %%%%%
                 serialMessage = "";
                 for (int i=0;i<numChan;i++) {
@@ -1743,7 +1771,7 @@ class Stream extends Thread {
 
     void sendAccelerometerData() {
         // UNFILTERED & FILTERED, Accel data is not affected by filters anyways
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i = 0; i < NUM_ACCEL_DIMS; i++) {
@@ -1817,7 +1845,7 @@ class Stream extends Thread {
         final int NUM_ANALOG_READS = analogChannels.length;
 
         // UNFILTERED & FILTERED, Aux data is not affected by filters anyways
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i = 0; i < NUM_ANALOG_READS; i++) {
@@ -1882,7 +1910,7 @@ class Stream extends Thread {
     void sendDigitalReadData() {
         final int NUM_DIGITAL_READS = w_digitalRead.getNumDigitalReads();
         // UNFILTERED & FILTERED, Aux data is not affected by filters anyways
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 for (int i = 0; i < NUM_DIGITAL_READS; i++) {
@@ -1946,7 +1974,7 @@ class Stream extends Thread {
     
     ////////////////////////////////////// Stream pulse data from W_PulseSensor
     void sendPulseData() {
-        if (this.filter==0 || this.filter==1) {
+        if (this.filter==false || this.filter==true) {
             // OSC
             if (this.protocol.equals("OSC")) {
                 //ADD BPM Data (BPM, Signal, IBI)
@@ -2055,7 +2083,7 @@ class Stream extends Thread {
             this.udp.log(false);
             output("UDP successfully connected");
         } else if (this.protocol.equals("LSL")) {
-            String stream_id = "openbcieeg12345";
+            String stream_id = "openbcigui";
             info_data = new LSL.StreamInfo(
                         this.streamName,
                         this.streamType,
@@ -2100,7 +2128,10 @@ class Stream extends Thread {
             attributes.append(str(this.nChanLSL));
             attributes.append(str(this.filter));
         } else if (this.protocol.equals("Serial")) {
-            // Add Serial Port Attributes %%%%%
+            attributes.append(this.dataType);
+            attributes.append(this.portName);
+            attributes.append(str(this.baudRate));
+            attributes.append(str(this.filter));
         }
         return attributes;
     }

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -218,6 +218,7 @@ class W_Networking extends Widget {
         //ignore top left button interaction when widgetSelector dropdown is active
         ignoreButtonCheck(guideButton);
         ignoreButtonCheck(dataOutputsButton);
+        filterButtonsCheck();
 
         if (dataDropdownsShouldBeClosed) { //this if takes care of the scenario where you select the same widget that is active...
             dataDropdownsShouldBeClosed = false;
@@ -396,7 +397,7 @@ class W_Networking extends Widget {
         }
 
         // Start Button
-        startButton = new Button_obci(x + w/2 - 70,y+h-40,200,20,"Start",14);
+        startButton = new Button_obci(x + w/2 - 70,y+h-40,200,20,"Start " + protocolMode + " Stream",14);
         startButton.setFont(p4,14);
         startButton.setColorNotPressed(color(184,220,105));
         startButton.setHelpText("Click here to Start and Stop the network stream for the chosen protocol.");
@@ -523,7 +524,7 @@ class W_Networking extends Widget {
             ;
     }
 
-    /* Create radio buttons for filter toggling */
+    /* Create toggle buttons for filter toggling */
     void createButton(String name) {
         cp5_networking.addToggle(name)
                 .setLabel("Off")
@@ -656,6 +657,30 @@ class W_Networking extends Widget {
             .getStyle() //need to grab style before affecting the paddingTop
             .setPaddingTop(3) //4-pixel vertical offset to center text
             ;
+    }
+
+    void filterButtonsCheck() {
+        boolean dropdownActive = false;
+        for (String datatypeName : datatypeNames) {
+            if (cp5_networking_dropdowns.get(ScrollableList.class, datatypeName).isInside()) {
+                dropdownActive = true; //if any datatype dropdowns are in-use...
+            }
+        }
+        if (dropdownActive) { //lock all filter buttons
+            if (!cp5_networking.get(Toggle.class, "filter1").isLock()) {
+                cp5_networking.get(Toggle.class, "filter1").lock();
+                cp5_networking.get(Toggle.class, "filter2").lock();
+                cp5_networking.get(Toggle.class, "filter3").lock();
+                cp5_networking.get(Toggle.class, "filter4").lock();
+            }
+        } else {
+            if (cp5_networking.get(Toggle.class, "filter1").isLock()) {
+                cp5_networking.get(Toggle.class, "filter1").unlock();
+                cp5_networking.get(Toggle.class, "filter2").unlock();
+                cp5_networking.get(Toggle.class, "filter3").unlock();
+                cp5_networking.get(Toggle.class, "filter4").unlock();
+            }
+        }
     }
 
     void screenResized() {
@@ -843,12 +868,12 @@ class W_Networking extends Widget {
     /* Change appearance of Button_obci to off */
     void turnOffButton() {
         startButton.setColorNotPressed(color(184,220,105));
-        startButton.setString("Start");
+        startButton.setString("Start " + protocolMode + " Stream");
     }
 
     void turnOnButton() {
         startButton.setColorNotPressed(color(224, 56, 45));
-        startButton.setString("Stop");
+        startButton.setString("Stop " + protocolMode + " Stream");
     }
 
     boolean getNetworkActive() {
@@ -2156,10 +2181,13 @@ void Protocol(int protocolIndex) {
         w_networking.protocolMode = "Serial";
         w_networking.disableCertainOutputs((int)w_networking.cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").getValue());
     }
-    println("Networking: Protocol mode set to " + w_networking.protocolMode);
+    println("Networking: Protocol mode set to " + w_networking.protocolMode + ". Stopping network");
     w_networking.screenResized();
     w_networking.showCP5();
     closeAllDropdowns();
+    if (!w_networking.networkActive) {
+        w_networking.turnOffButton();
+    }
 }
 
 void dataType1(int n) {

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -60,11 +60,11 @@ class W_Networking extends Widget {
     Boolean lsl_visible;
     Boolean serial_visible;
     List<String> dataTypes;
-    Button startButton;
+    Button_obci startButton;
     Boolean cp5ElementsAreActive = false;
     Boolean previousCP5State = false;
-    Button guideButton;
-    Button dataOutputsButton;
+    Button_obci guideButton;
+    Button_obci dataOutputsButton;
 
     /* Networking */
     Boolean networkActive;
@@ -170,7 +170,7 @@ class W_Networking extends Widget {
             cp5Map.put(datatypeNames[i], int(cp5_networking_dropdowns.get(ScrollableList.class, datatypeNames[i]).getValue()));
             //filter radio buttons
             String filterName = "filter" + (i+1);
-            cp5Map.put(filterName, cp5_networking.get(RadioButton.class, filterName).getState(0));
+            cp5Map.put(filterName, cp5_networking.get(Button.class, filterName).getBooleanValue());
         }
         //osc textfields
         copyCP5TextToMap(oscTextFieldNames, cp5Map);
@@ -299,21 +299,20 @@ class W_Networking extends Widget {
         //draw dropdown strokes
         pushStyle();
         fill(255);
-        if (!protocolMode.equals("Serial")) {
-            for (int i = 0; i < datatypeNames.length; i++) {
-                rect(cp5_networking_dropdowns.getController(datatypeNames[i]).getPosition()[0] - 1, cp5_networking_dropdowns.getController(datatypeNames[i]).getPosition()[1] - 1, itemWidth + 2, cp5_networking_dropdowns.getController(datatypeNames[i]).getHeight()+2);
-            }
-        } else {
+        if (protocolMode.equals("Serial")) {
             rect(cp5_networking_portName.getController("port_name").getPosition()[0] - 1, cp5_networking_portName.getController("port_name").getPosition()[1] - 1, cp5_networking_portName.getController("port_name").getWidth() + 2, cp5_networking_portName.getController("port_name").getHeight()+2);
             cp5_networking_portName.draw();
             rect(cp5_networking_baudRate.getController("baud_rate").getPosition()[0] - 1, cp5_networking_baudRate.getController("baud_rate").getPosition()[1] - 1, cp5_networking_baudRate.getController("baud_rate").getWidth() + 2, cp5_networking_baudRate.getController("baud_rate").getHeight()+2);
             cp5_networking_baudRate.draw();
             rect(cp5_networking_dropdowns.getController("dataType1").getPosition()[0] - 1, cp5_networking_dropdowns.getController("dataType1").getPosition()[1] - 1, cp5_networking_dropdowns.getController("dataType1").getWidth() + 2, cp5_networking_dropdowns.getController("dataType1").getHeight()+2);
+        } else {
+            for (int i = 0; i < datatypeNames.length; i++) {
+                rect(cp5_networking_dropdowns.getController(datatypeNames[i]).getPosition()[0] - 1, cp5_networking_dropdowns.getController(datatypeNames[i]).getPosition()[1] - 1, itemWidth + 2, cp5_networking_dropdowns.getController(datatypeNames[i]).getHeight()+2);
+            }
         }
         cp5_networking_dropdowns.draw();
         popStyle();
 
-        // cp5_networking_dropdowns.draw();
         int headerFontSize = 18;
         fill(0,0,0);// Background fill: white
         textFont(h1, headerFontSize);
@@ -387,23 +386,23 @@ class W_Networking extends Widget {
         createBaudDropdown("baud_rate", baudRates);
         /* General Elements */
 
-        createRadioButtons("filter1");
-        createRadioButtons("filter2");
-        createRadioButtons("filter3");
-        createRadioButtons("filter4");
+        createButtons("filter1");
+        createButtons("filter2");
+        createButtons("filter3");
+        createButtons("filter4");
 
         for (int i = 0; i < datatypeNames.length; i++) {
             createDropdown(datatypeNames[i], dataTypes);
         }
 
         // Start Button
-        startButton = new Button(x + w/2 - 70,y+h-40,200,20,"Start",14);
+        startButton = new Button_obci(x + w/2 - 70,y+h-40,200,20,"Start",14);
         startButton.setFont(p4,14);
         startButton.setColorNotPressed(color(184,220,105));
         startButton.setHelpText("Click here to Start and Stop the network stream for the chosen protocol.");
 
         // Networking Guide button
-        guideButton = new Button(x0 + 2, y0 + navH + 2, 125, navH - 6,"Networking Guide", 14);
+        guideButton = new Button_obci(x0 + 2, y0 + navH + 2, 125, navH - 6,"Networking Guide", 14);
         guideButton.setCornerRoundess((int)(navHeight-6));
         guideButton.setFont(p5,12);
         guideButton.setColorNotPressed(color(57,128,204));
@@ -414,7 +413,7 @@ class W_Networking extends Widget {
 
         //Data outputs spreadsheet button
         // Networking Data Type Guide button
-        dataOutputsButton = new Button(x0 + 2*2 + guideButton.but_dx, y0 + navH + 2, 100, navH - 6,"Data Outputs", 14);
+        dataOutputsButton = new Button_obci(x0 + 2*2 + guideButton.but_dx, y0 + navH + 2, 100, navH - 6,"Data Outputs", 14);
         dataOutputsButton.setCornerRoundess((int)(navHeight-6));
         dataOutputsButton.setFont(p5,12);
         dataOutputsButton.setColorNotPressed(color(57,128,204));
@@ -465,19 +464,19 @@ class W_Networking extends Widget {
             cp5_networking_dropdowns.get(ScrollableList.class, "dataType4").setVisible(false);
         }
 
-        cp5_networking.get(RadioButton.class, "filter1").setVisible(true);
+        cp5_networking.get(Button.class, "filter1").setVisible(true);
         if (!serial_visible) {
-            cp5_networking.get(RadioButton.class, "filter2").setVisible(true);
-            cp5_networking.get(RadioButton.class, "filter3").setVisible(true);
+            cp5_networking.get(Button.class, "filter2").setVisible(true);
+            cp5_networking.get(Button.class, "filter3").setVisible(true);
         } else {
-            cp5_networking.get(RadioButton.class, "filter2").setVisible(false);
-            cp5_networking.get(RadioButton.class, "filter3").setVisible(false);
+            cp5_networking.get(Button.class, "filter2").setVisible(false);
+            cp5_networking.get(Button.class, "filter3").setVisible(false);
         }
         //Draw a 4th Filter button option if we are using OSC!
         if (protocolMode.equals("OSC")) {
-            cp5_networking.get(RadioButton.class, "filter4").setVisible(true);
+            cp5_networking.get(Button.class, "filter4").setVisible(true);
         } else {
-            cp5_networking.get(RadioButton.class, "filter4").setVisible(false);
+            cp5_networking.get(Button.class, "filter4").setVisible(false);
         }
     }
 
@@ -525,21 +524,15 @@ class W_Networking extends Widget {
     }
 
     /* Create radio buttons for filter toggling */
-    void createRadioButtons(String name) {
-        String id = name.substring(name.length()-1);
-        cp5_networking.addRadioButton(name)
-                .setSize(20,20)
+    void createButtons(String name) {
+        cp5_networking.addButton(name)
+                .setLabel("Off")
+                .setSize(35,20)
                 .setColorForeground(color(120))
                 .setColorBackground(color(200,200,200)) // text field bg color
                 .setColorActive(color(184,220,105))
                 .setColorLabel(color(0))
-                .setItemsPerRow(2)
-                .setSpacingColumn(40)
-                .addItem("filter_stream_"+id, 0)
-                // .addItem("Off",0)
-                // .addItem("On",1)
-                .hideLabels()
-                .activate(0) //filter on by default
+                .setSwitch(false)
                 .setVisible(false)
                 ;
     }
@@ -715,10 +708,10 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "OSC_ip4").setPosition(column4, row2 - offset);
             cp5_networking.get(Textfield.class, "OSC_port4").setPosition(column4, row3 - offset);
             cp5_networking.get(Textfield.class, "OSC_address4").setPosition(column4, row4 - offset); //adding forth column only for OSC
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter4").setPosition(column4 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter4").setPosition(column4 + filtOffsetX, row5 + filtOffsetY);
         } else if (protocolMode.equals("UDP")) {
             for (String textField : udpTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -729,9 +722,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "UDP_port2").setPosition(column2, row3 - offset);
             cp5_networking.get(Textfield.class, "UDP_ip3").setPosition(column3, row2 - offset);
             cp5_networking.get(Textfield.class, "UDP_port3").setPosition(column3, row3 - offset);
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("LSL")) {
             for (String textField : lslTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -742,9 +735,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "LSL_type2").setPosition(column2,row3 - offset);
             cp5_networking.get(Textfield.class, "LSL_name3").setPosition(column3,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type3").setPosition(column3,row3 - offset);
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("Serial")) {
             //Serial Specific
             cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setPosition(column1, row2-offset);
@@ -754,7 +747,7 @@ class W_Networking extends Widget {
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (comPorts.size()+1)*(navH-4));
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (4)*(navH-4)); //
             cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(halfWidth, (5)*(navH-4)); //halfWidth
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row3 + filtOffsetY);
+            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row3 + filtOffsetY);
         }
 
         cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setPosition(column1, row1-offset);
@@ -831,14 +824,14 @@ class W_Networking extends Widget {
         cp5_networking_portName.get(ScrollableList.class, "port_name").setVisible(false);
         cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setVisible(false);
 
-        cp5_networking.get(RadioButton.class, "filter1").setVisible(false);
-        cp5_networking.get(RadioButton.class, "filter2").setVisible(false);
-        cp5_networking.get(RadioButton.class, "filter3").setVisible(false);
-        cp5_networking.get(RadioButton.class, "filter4").setVisible(false);
+        cp5_networking.get(Button.class, "filter1").setVisible(false);
+        cp5_networking.get(Button.class, "filter2").setVisible(false);
+        cp5_networking.get(Button.class, "filter3").setVisible(false);
+        cp5_networking.get(Button.class, "filter4").setVisible(false);
 
     }
 
-    /* Change appearance of Button to off */
+    /* Change appearance of Button_obci to off */
     void turnOffButton() {
         startButton.setColorNotPressed(color(184,220,105));
         startButton.setString("Start");
@@ -881,7 +874,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port1").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address1").getText();
-                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, ip, port, address, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -890,7 +883,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port2").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address2").getText();
-                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, ip, port, address, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -899,7 +892,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port3").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address3").getText();
-                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, ip, port, address, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -908,7 +901,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip4").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port4").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address4").getText();
-                filt_pos = cp5_networking.get(RadioButton.class, "filter4").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter4").getBooleanValue();
                 stream4 = new Stream(dt4, ip, port, address, filt_pos, nchan);
             } else {
                 stream4 = null;
@@ -919,7 +912,7 @@ class W_Networking extends Widget {
             if (!dt1.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port1").getText());
-                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, ip, port, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -927,7 +920,7 @@ class W_Networking extends Widget {
             if (!dt2.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port2").getText());
-                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, ip, port, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -935,7 +928,7 @@ class W_Networking extends Widget {
             if (!dt3.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port3").getText());
-                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, ip, port, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -949,7 +942,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name1").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type1").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt1);
-                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -958,7 +951,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name2").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type2").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt2);
-                filt_pos = cp5_networking.get(RadioButton.class, "filter2").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -967,7 +960,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name3").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type3").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt3);
-                filt_pos = cp5_networking.get(RadioButton.class, "filter3").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -978,7 +971,7 @@ class W_Networking extends Widget {
                 println("ComPort: " + name);
                 println("Baudrate: " + Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue()))));
                 baudRate = Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue())));
-                filt_pos = cp5_networking.get(RadioButton.class, "filter1").getState(0);
+                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, name, baudRate, filt_pos, pApplet, nchan);  //String dataType, String portName, int baudRate, int filter, PApplet _this
             } else {
                 stream1 = null;

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -49,6 +49,10 @@ class W_Networking extends Widget {
     int row5;
     int itemWidth = 96;
     private final float datatypeDropdownScaling = .35;
+    private final int filtButW = 20;
+    private final int filtButH = 20;
+    private final int filtOffsetX = (itemWidth / 2) - 10;
+    private final int filtOffsetY = -15;
 
     /* UI */
     Boolean osc_visible;
@@ -525,18 +529,18 @@ class W_Networking extends Widget {
     void createRadioButtons(String name) {
         String id = name.substring(name.length()-1);
         cp5_networking.addRadioButton(name)
-                .setSize(10,10)
+                .setSize(20,20)
                 .setColorForeground(color(120))
                 .setColorBackground(color(200,200,200)) // text field bg color
                 .setColorActive(color(184,220,105))
                 .setColorLabel(color(0))
                 .setItemsPerRow(2)
                 .setSpacingColumn(40)
-                .addItem(id + "-Off", 0)
-                .addItem(id + "-On", 1)
+                .addItem("filter_stream_"+id, 0)
                 // .addItem("Off",0)
                 // .addItem("On",1)
-                .activate(0)
+                .hideLabels()
+                .activate(0) //filter on by default
                 .setVisible(false)
                 ;
     }
@@ -676,6 +680,7 @@ class W_Networking extends Widget {
         row4 = y+7*h/10;
         row5 = y+8*h/10;
         int offset = 15;//This value has been fine-tuned to look proper in windowed mode 1024*768 and fullscreen on 1920x1080
+        
 
         //reset the button positions using new x and y
         startButton.setPos(x + w/2 - 70, y + h - 40 );
@@ -711,10 +716,10 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "OSC_ip4").setPosition(column4, row2 - offset);
             cp5_networking.get(Textfield.class, "OSC_port4").setPosition(column4, row3 - offset);
             cp5_networking.get(Textfield.class, "OSC_address4").setPosition(column4, row4 - offset); //adding forth column only for OSC
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1, row5 - 10);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2, row5 - 10);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3, row5 - 10);
-            cp5_networking.get(RadioButton.class, "filter4").setPosition(column4, row5 - 10);
+            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter4").setPosition(column4 + filtOffsetX, row5 + filtOffsetY);
         } else if (protocolMode.equals("UDP")) {
             for (String textField : udpTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -725,9 +730,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "UDP_port2").setPosition(column2, row3 - offset);
             cp5_networking.get(Textfield.class, "UDP_ip3").setPosition(column3, row2 - offset);
             cp5_networking.get(Textfield.class, "UDP_port3").setPosition(column3, row3 - offset);
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1, row4 - 10);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2, row4 - 10);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3, row4 - 10);
+            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("LSL")) {
             for (String textField : lslTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -741,9 +746,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "LSL_name3").setPosition(column3,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type3").setPosition(column3,row3 - offset);
             cp5_networking.get(Textfield.class, "LSL_numchan3").setPosition(column3,row4 - offset);
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1, row5 - 10);
-            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2, row5 - 10);
-            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3, row5 - 10);
+            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(RadioButton.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
         } else if (protocolMode.equals("Serial")) {
             //Serial Specific
             cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setPosition(column1, row2-offset);
@@ -753,7 +758,7 @@ class W_Networking extends Widget {
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (comPorts.size()+1)*(navH-4));
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (4)*(navH-4)); //
             cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(halfWidth, (5)*(navH-4)); //halfWidth
-            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1, row3 - 10);
+            cp5_networking.get(RadioButton.class, "filter1").setPosition(column1 + filtOffsetX, row3 + filtOffsetY);
         }
 
         cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setPosition(column1, row1-offset);
@@ -1518,7 +1523,7 @@ class Stream extends Thread {
     }
 
     void sendFFTData() {
-        // UNFILTERED, for now, maybe this should be changed -RW
+        // UNFILTERED & FILTERED ... influenced globally by the FFT filters dropdown
         //EEG/FFT readings above 125Hz don't typically travel through the skull
         //So for now, only send out 0-125Hz with 1 bin per Hz
         //Bin 10 == 10Hz frequency range

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -2210,7 +2210,6 @@ void baud_rate(int n) {
     w_networking.closeAllDropdowns();
 }
 void filter1(int n) {
-    println("filter1=="+n);
     String s = n == 1 ? "On" : "Off";
     w_networking.cp5_networking.get(Toggle.class, "filter1").setLabel(s);
     w_networking.closeAllDropdowns();

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -51,7 +51,7 @@ class W_Networking extends Widget {
     private final float datatypeDropdownScaling = .35;
     private final int filtButW = 40;
     private final int filtButH = 20;
-    private final int filtOffsetX = (itemWidth / 2) - (filtButW / 2);
+    private int filtOffsetX = (itemWidth / 2) - (filtButW / 2);
     private final int filtOffsetY = -15;
 
     /* UI */
@@ -706,7 +706,7 @@ class W_Networking extends Widget {
         row4 = y+7*h/10;
         row5 = y+8*h/10;
         int offset = 15;//This value has been fine-tuned to look proper in windowed mode 1024*768 and fullscreen on 1920x1080
-        
+        filtOffsetX = (itemWidth / 2) - (filtButW / 2); //Recalculate filter button X position
 
         //reset the button positions using new x and y
         startButton.setPos(x + w/2 - 70, y + h - 40 );

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -49,9 +49,9 @@ class W_Networking extends Widget {
     int row5;
     int itemWidth = 96;
     private final float datatypeDropdownScaling = .35;
-    private final int filtButW = 20;
+    private final int filtButW = 40;
     private final int filtButH = 20;
-    private final int filtOffsetX = (itemWidth / 2) - 10;
+    private final int filtOffsetX = (itemWidth / 2) - (filtButW / 2);
     private final int filtOffsetY = -15;
 
     /* UI */
@@ -170,7 +170,7 @@ class W_Networking extends Widget {
             cp5Map.put(datatypeNames[i], int(cp5_networking_dropdowns.get(ScrollableList.class, datatypeNames[i]).getValue()));
             //filter radio buttons
             String filterName = "filter" + (i+1);
-            cp5Map.put(filterName, cp5_networking.get(Button.class, filterName).getBooleanValue());
+            cp5Map.put(filterName, cp5_networking.get(Toggle.class, filterName).getBooleanValue());
         }
         //osc textfields
         copyCP5TextToMap(oscTextFieldNames, cp5Map);
@@ -386,10 +386,10 @@ class W_Networking extends Widget {
         createBaudDropdown("baud_rate", baudRates);
         /* General Elements */
 
-        createButtons("filter1");
-        createButtons("filter2");
-        createButtons("filter3");
-        createButtons("filter4");
+        createButton("filter1");
+        createButton("filter2");
+        createButton("filter3");
+        createButton("filter4");
 
         for (int i = 0; i < datatypeNames.length; i++) {
             createDropdown(datatypeNames[i], dataTypes);
@@ -464,19 +464,19 @@ class W_Networking extends Widget {
             cp5_networking_dropdowns.get(ScrollableList.class, "dataType4").setVisible(false);
         }
 
-        cp5_networking.get(Button.class, "filter1").setVisible(true);
+        cp5_networking.get(Toggle.class, "filter1").setVisible(true);
         if (!serial_visible) {
-            cp5_networking.get(Button.class, "filter2").setVisible(true);
-            cp5_networking.get(Button.class, "filter3").setVisible(true);
+            cp5_networking.get(Toggle.class, "filter2").setVisible(true);
+            cp5_networking.get(Toggle.class, "filter3").setVisible(true);
         } else {
-            cp5_networking.get(Button.class, "filter2").setVisible(false);
-            cp5_networking.get(Button.class, "filter3").setVisible(false);
+            cp5_networking.get(Toggle.class, "filter2").setVisible(false);
+            cp5_networking.get(Toggle.class, "filter3").setVisible(false);
         }
         //Draw a 4th Filter button option if we are using OSC!
         if (protocolMode.equals("OSC")) {
-            cp5_networking.get(Button.class, "filter4").setVisible(true);
+            cp5_networking.get(Toggle.class, "filter4").setVisible(true);
         } else {
-            cp5_networking.get(Button.class, "filter4").setVisible(false);
+            cp5_networking.get(Toggle.class, "filter4").setVisible(false);
         }
     }
 
@@ -524,17 +524,26 @@ class W_Networking extends Widget {
     }
 
     /* Create radio buttons for filter toggling */
-    void createButtons(String name) {
-        cp5_networking.addButton(name)
+    void createButton(String name) {
+        cp5_networking.addToggle(name)
                 .setLabel("Off")
-                .setSize(35,20)
+                .setSize(filtButW, filtButH)
                 .setColorForeground(color(120))
                 .setColorBackground(color(200,200,200)) // text field bg color
                 .setColorActive(color(184,220,105))
                 .setColorLabel(color(0))
-                .setSwitch(false)
                 .setVisible(false)
                 ;
+        cp5_networking.getController(name)
+            .getCaptionLabel() //the caption label is the text object in the primary bar
+            .toUpperCase(false) //DO NOT AUTOSET TO UPPERCASE!!!
+            .setText("Off")
+            .setFont(h4)
+            .setSize(14)
+            .getStyle() //need to grab style before affecting margin and padding
+            .setMargin(-25, 0, 0, 0)
+            .setPaddingLeft(10)
+            ;
     }
 
     /* Creating DataType Dropdowns */
@@ -708,10 +717,10 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "OSC_ip4").setPosition(column4, row2 - offset);
             cp5_networking.get(Textfield.class, "OSC_port4").setPosition(column4, row3 - offset);
             cp5_networking.get(Textfield.class, "OSC_address4").setPosition(column4, row4 - offset); //adding forth column only for OSC
-            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter4").setPosition(column4 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter1").setPosition(column1 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter2").setPosition(column2 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter3").setPosition(column3 + filtOffsetX, row5 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter4").setPosition(column4 + filtOffsetX, row5 + filtOffsetY);
         } else if (protocolMode.equals("UDP")) {
             for (String textField : udpTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -722,9 +731,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "UDP_port2").setPosition(column2, row3 - offset);
             cp5_networking.get(Textfield.class, "UDP_ip3").setPosition(column3, row2 - offset);
             cp5_networking.get(Textfield.class, "UDP_port3").setPosition(column3, row3 - offset);
-            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("LSL")) {
             for (String textField : lslTextFieldNames) {
                 cp5_networking.get(Textfield.class, textField).setWidth(itemWidth);
@@ -735,9 +744,9 @@ class W_Networking extends Widget {
             cp5_networking.get(Textfield.class, "LSL_type2").setPosition(column2,row3 - offset);
             cp5_networking.get(Textfield.class, "LSL_name3").setPosition(column3,row2 - offset);
             cp5_networking.get(Textfield.class, "LSL_type3").setPosition(column3,row3 - offset);
-            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
-            cp5_networking.get(Button.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter1").setPosition(column1 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter2").setPosition(column2 + filtOffsetX, row4 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter3").setPosition(column3 + filtOffsetX, row4 + filtOffsetY);
         } else if (protocolMode.equals("Serial")) {
             //Serial Specific
             cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setPosition(column1, row2-offset);
@@ -747,7 +756,7 @@ class W_Networking extends Widget {
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (comPorts.size()+1)*(navH-4));
             // cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(fullColumnWidth, (4)*(navH-4)); //
             cp5_networking_portName.get(ScrollableList.class, "port_name").setSize(halfWidth, (5)*(navH-4)); //halfWidth
-            cp5_networking.get(Button.class, "filter1").setPosition(column1 + filtOffsetX, row3 + filtOffsetY);
+            cp5_networking.get(Toggle.class, "filter1").setPosition(column1 + filtOffsetX, row3 + filtOffsetY);
         }
 
         cp5_networking_dropdowns.get(ScrollableList.class, "dataType1").setPosition(column1, row1-offset);
@@ -824,10 +833,10 @@ class W_Networking extends Widget {
         cp5_networking_portName.get(ScrollableList.class, "port_name").setVisible(false);
         cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").setVisible(false);
 
-        cp5_networking.get(Button.class, "filter1").setVisible(false);
-        cp5_networking.get(Button.class, "filter2").setVisible(false);
-        cp5_networking.get(Button.class, "filter3").setVisible(false);
-        cp5_networking.get(Button.class, "filter4").setVisible(false);
+        cp5_networking.get(Toggle.class, "filter1").setVisible(false);
+        cp5_networking.get(Toggle.class, "filter2").setVisible(false);
+        cp5_networking.get(Toggle.class, "filter3").setVisible(false);
+        cp5_networking.get(Toggle.class, "filter4").setVisible(false);
 
     }
 
@@ -874,7 +883,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port1").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address1").getText();
-                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, ip, port, address, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -883,7 +892,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port2").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address2").getText();
-                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, ip, port, address, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -892,7 +901,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port3").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address3").getText();
-                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, ip, port, address, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -901,7 +910,7 @@ class W_Networking extends Widget {
                 ip = cp5_networking.get(Textfield.class, "OSC_ip4").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "OSC_port4").getText());
                 address = cp5_networking.get(Textfield.class, "OSC_address4").getText();
-                filt_pos = cp5_networking.get(Button.class, "filter4").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter4").getBooleanValue();
                 stream4 = new Stream(dt4, ip, port, address, filt_pos, nchan);
             } else {
                 stream4 = null;
@@ -912,7 +921,7 @@ class W_Networking extends Widget {
             if (!dt1.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip1").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port1").getText());
-                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, ip, port, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -920,7 +929,7 @@ class W_Networking extends Widget {
             if (!dt2.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip2").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port2").getText());
-                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, ip, port, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -928,7 +937,7 @@ class W_Networking extends Widget {
             if (!dt3.equals("None")) {
                 ip = cp5_networking.get(Textfield.class, "UDP_ip3").getText();
                 port = Integer.parseInt(cp5_networking.get(Textfield.class, "UDP_port3").getText());
-                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, ip, port, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -942,7 +951,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name1").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type1").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt1);
-                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream1 = null;
@@ -951,7 +960,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name2").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type2").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt2);
-                filt_pos = cp5_networking.get(Button.class, "filter2").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter2").getBooleanValue();
                 stream2 = new Stream(dt2, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream2 = null;
@@ -960,7 +969,7 @@ class W_Networking extends Widget {
                 name = cp5_networking.get(Textfield.class, "LSL_name3").getText();
                 type = cp5_networking.get(Textfield.class, "LSL_type3").getText();
                 nChanLSL = getDataTypeNumChanLSL(dt3);
-                filt_pos = cp5_networking.get(Button.class, "filter3").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter3").getBooleanValue();
                 stream3 = new Stream(dt3, name, type, nChanLSL, filt_pos, nchan);
             } else {
                 stream3 = null;
@@ -971,7 +980,7 @@ class W_Networking extends Widget {
                 println("ComPort: " + name);
                 println("Baudrate: " + Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue()))));
                 baudRate = Integer.parseInt(baudRates.get((int)(cp5_networking_baudRate.get(ScrollableList.class, "baud_rate").getValue())));
-                filt_pos = cp5_networking.get(Button.class, "filter1").getBooleanValue();
+                filt_pos = cp5_networking.get(Toggle.class, "filter1").getBooleanValue();
                 stream1 = new Stream(dt1, name, baudRate, filt_pos, pApplet, nchan);  //String dataType, String portName, int baudRate, int filter, PApplet _this
             } else {
                 stream1 = null;
@@ -2173,14 +2182,23 @@ void baud_rate(int n) {
     w_networking.closeAllDropdowns();
 }
 void filter1(int n) {
+    println("filter1=="+n);
+    String s = n == 1 ? "On" : "Off";
+    w_networking.cp5_networking.get(Toggle.class, "filter1").setLabel(s);
     w_networking.closeAllDropdowns();
 }
 void filter2(int n) {
+    String s = n == 1 ? "On" : "Off";
+    w_networking.cp5_networking.get(Toggle.class, "filter2").setLabel(s);
     w_networking.closeAllDropdowns();
 }
 void filter3(int n) {
+    String s = n == 1 ? "On" : "Off";
+    w_networking.cp5_networking.get(Toggle.class, "filter3").setLabel(s);
     w_networking.closeAllDropdowns();
 }
 void filter4(int n) {
+    String s = n == 1 ? "On" : "Off";
+    w_networking.cp5_networking.get(Toggle.class, "filter4").setLabel(s);
     w_networking.closeAllDropdowns();
 }

--- a/OpenBCI_GUI/W_NovaAux.pde
+++ b/OpenBCI_GUI/W_NovaAux.pde
@@ -24,8 +24,6 @@ class W_NovaAux extends Widget {
     private int arInitialVertScaleIndex = 5;
     private int arInitialHorizScaleIndex = 0;
 
-    //Button analogModeButton;
-
     W_NovaAux(PApplet _parent) {
         super(_parent); //calls the parent CONSTRUCTOR method of Widget (DON'T REMOVE)
 

--- a/OpenBCI_GUI/W_Playback.pde
+++ b/OpenBCI_GUI/W_Playback.pde
@@ -22,7 +22,7 @@ class W_playback extends Widget {
     //allow access to dataProcessing
     DataProcessing dataProcessing;
     //Set up variables for Playback widget
-    Button selectPlaybackFileButton;
+    Button_obci selectPlaybackFileButton;
     MenuList playbackMenuList;
     //Used for spacing
     int padding = 10;
@@ -36,7 +36,7 @@ class W_playback extends Widget {
         super(_parent); //calls the parent CONSTRUCTOR method of Widget (DON'T REMOVE)
 
         //make a button to load new files
-        selectPlaybackFileButton = new Button (
+        selectPlaybackFileButton = new Button_obci (
             x + w/2 - (padding*2),
             y - navHeight + 2,
             200,

--- a/OpenBCI_GUI/W_PulseSensor.pde
+++ b/OpenBCI_GUI/W_PulseSensor.pde
@@ -66,7 +66,7 @@ class W_PulseSensor extends Widget {
     int IBI = 600;             // int that holds the time interval between beats! Must be seeded!
     boolean Pulse = false;     // "True" when User's live heartbeat is detected. "False" when not a "live beat".
     int lastProcessedDataPacketInd = 0;
-    Button analogModeButton;
+    Button_obci analogModeButton;
 
     private AnalogCapableBoard analogBoard;
 
@@ -83,7 +83,7 @@ class W_PulseSensor extends Widget {
         setPulseWidgetVariables();
         initializePulseFinderVariables();
 
-        analogModeButton = new Button((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
+        analogModeButton = new Button_obci((int)(x + 3), (int)(y + 3 - navHeight), 128, navHeight - 6, "ANALOG TOGGLE", 12);
         analogModeButton.setCornerRoundess((int)(navHeight-6));
         analogModeButton.setFont(p5,12);
         analogModeButton.setColorNotPressed(color(57,128,204));

--- a/OpenBCI_GUI/W_Spectrogram.pde
+++ b/OpenBCI_GUI/W_Spectrogram.pde
@@ -18,7 +18,7 @@ class W_Spectrogram extends Widget {
     int xPos = 0;
     int hueLimit = 160;
 
-    Button widgetTemplateButton;
+    Button_obci widgetTemplateButton;
     PImage dataImg;
     int dataImageW = 1800;
     int dataImageH = 200;
@@ -97,7 +97,7 @@ class W_Spectrogram extends Widget {
         addDropdown("SpectrogramSampleRate", "Samples", Arrays.asList(settings.spectSampleRateArray), settings.spectSampleRateSave);
         addDropdown("SpectrogramLogLin", "Log/Lin", Arrays.asList(settings.fftLogLinArray), settings.spectLogLinSave);
 
-        widgetTemplateButton = new Button (x + int(spectChanSelectBot.tri_xpos) + 10, y + navHeight + 2, 142, navHeight - 4, "Save Spectrogram", 10);
+        widgetTemplateButton = new Button_obci (x + int(spectChanSelectBot.tri_xpos) + 10, y + navHeight + 2, 142, navHeight - 4, "Save Spectrogram", 10);
         widgetTemplateButton.setFont(p4, 14);
     }
 

--- a/OpenBCI_GUI/W_Template.pde
+++ b/OpenBCI_GUI/W_Template.pde
@@ -14,7 +14,7 @@ class W_template extends Widget {
 
     //to see all core variables/methods of the Widget class, refer to Widget.pde
     //put your custom variables here...
-    Button widgetTemplateButton;
+    Button_obci widgetTemplateButton;
 
     W_template(PApplet _parent){
         super(_parent); //calls the parent CONSTRUCTOR method of Widget (DON'T REMOVE)
@@ -26,7 +26,7 @@ class W_template extends Widget {
         addDropdown("Dropdown2", "Drop 2", Arrays.asList("C", "D", "E"), 1);
         addDropdown("Dropdown3", "Drop 3", Arrays.asList("F", "G", "H", "I"), 3);
 
-        widgetTemplateButton = new Button (x + w/2, y + h/2, 200, navHeight, "Design Your Own Widget!", 12);
+        widgetTemplateButton = new Button_obci (x + w/2, y + h/2, 200, navHeight, "Design Your Own Widget!", 12);
         widgetTemplateButton.setFont(p4, 14);
         widgetTemplateButton.setURL("https://openbci.github.io/Documentation/docs/06Software/01-OpenBCISoftware/GUIWidgets#custom-widget");
     }

--- a/OpenBCI_GUI/W_TimeSeries.pde
+++ b/OpenBCI_GUI/W_TimeSeries.pde
@@ -24,7 +24,7 @@ class W_timeSeries extends Widget {
     float playbackWidgetHeight;
     int channelBarHeight;
 
-    Button hardwareSettingsButton;
+    Button_obci hardwareSettingsButton;
 
     ChannelBar[] channelBars;
     PlaybackScrollbar scrollbar;
@@ -102,7 +102,7 @@ class W_timeSeries extends Widget {
         }
 
         if(currentBoard instanceof ADS1299SettingsBoard) {
-            hardwareSettingsButton = new Button((int)(x + 3), (int)(y + navHeight + 3), 120, navHeight - 6, "Hardware Settings", 12);
+            hardwareSettingsButton = new Button_obci((int)(x + 3), (int)(y + navHeight + 3), 120, navHeight - 6, "Hardware Settings", 12);
             hardwareSettingsButton.setCornerRoundess((int)(navHeight-6));
             hardwareSettingsButton.setFont(p5,12);
             // hardwareSettingsButton.setStrokeColor((int)(color(150)));
@@ -356,9 +356,9 @@ class ChannelBar{
     int channelIndex; //duh
     String channelString;
     int x, y, w, h;
-    Button onOffButton;
+    Button_obci onOffButton;
     int onOff_diameter, impButton_diameter;
-    Button impCheckButton;
+    Button_obci impCheckButton;
 
     GPlot plot; //the actual grafica-based GPlot that will be rendering the Time Series trace
     GPointsArray channelPoints;
@@ -392,7 +392,7 @@ class ChannelBar{
             onOff_diameter = h - 2;
         }
 
-        onOffButton = new Button (x + 6, y + int(h/2) - int(onOff_diameter/2), onOff_diameter, onOff_diameter, channelString, fontInfo.buttonLabel_size);
+        onOffButton = new Button_obci (x + 6, y + int(h/2) - int(onOff_diameter/2), onOff_diameter, onOff_diameter, channelString, fontInfo.buttonLabel_size);
         onOffButton.setHelpText("Click to toggle channel " + channelString + ".");
         onOffButton.setFont(h2, 16);
         onOffButton.setCircleButton(true);
@@ -402,7 +402,7 @@ class ChannelBar{
 
         if(currentBoard instanceof ImpedanceSettingsBoard) {
             impButton_diameter = 22;
-            impCheckButton = new Button (x + 36, y + int(h/2) - int(impButton_diameter/2), impButton_diameter, impButton_diameter, "\u2126", fontInfo.buttonLabel_size);
+            impCheckButton = new Button_obci (x + 36, y + int(h/2) - int(impButton_diameter/2), impButton_diameter, impButton_diameter, "\u2126", fontInfo.buttonLabel_size);
             impCheckButton.setHelpText("Click to toggle impedance check for channel " + channelString + ".");
             impCheckButton.setFont(h3, 16); //override the default font and fontsize
             impCheckButton.setCircleButton(true);
@@ -533,7 +533,7 @@ class ChannelBar{
         fill(255);
         rect(x,y,w,h);
 
-        //draw onOff Button
+        //draw onOff Button_obci
         onOffButton.draw();
 
         //draw plot
@@ -554,7 +554,7 @@ class ChannelBar{
         }
         plot.endDraw();
 
-        //draw impedance check Button
+        //draw impedance check Button_obci
         if(currentBoard instanceof ImpedanceSettingsBoard) {
             impCheckButton.draw();
 
@@ -706,7 +706,7 @@ class PlaybackScrollbar {
     private float sposMin, sposMax; // max and min values of slider
     private boolean over;           // is the mouse over the slider?
     private boolean locked;
-    private Button skipToStartButton;
+    private Button_obci skipToStartButton;
     private int skipToStart_diameter;
     private String currentAbsoluteTimeToDisplay = "";
     private String currentTimeInSecondsToDisplay = "";
@@ -729,7 +729,7 @@ class PlaybackScrollbar {
 
         //Let's make a button to return to the start of playback!!
         skipToStart_diameter = 30;
-        skipToStartButton = new Button (int(xp) + int(skipToStart_diameter*.5), int(yp) + int(sh/2) - skipToStart_diameter, skipToStart_diameter, skipToStart_diameter, "");
+        skipToStartButton = new Button_obci (int(xp) + int(skipToStart_diameter*.5), int(yp) + int(sh/2) - skipToStart_diameter, skipToStart_diameter, skipToStart_diameter, "");
         skipToStartButton.setColorNotPressed(color(235)); //Set channel button background colors
         skipToStartButton.hasStroke(false);
         PImage bgImage = loadImage("skipToStart-30x26.png");

--- a/OpenBCI_GUI/Widget.pde
+++ b/OpenBCI_GUI/Widget.pde
@@ -354,7 +354,7 @@ class Widget{
         }
     }
 
-    void ignoreButtonCheck(Button b) {
+    void ignoreButtonCheck(Button_obci b) {
         //ignore top left button interaction when widgetSelector dropdown is active
         if (dropdownIsActive) {
             b.setIgnoreHover(true);


### PR DESCRIPTION
- [x] Remove #Chan Textfield from Networking - Closes #644 
- [x] save networking filters as booleans to JSON
- [x] simplify networking filter buttons
- [x] replace filter radio buttons with cp5 Toggles 
- [x] display "on" or "off" next to filter buttons aligning with current state
- [x] refine/troubleshoot filter buttons (disable when data type dropdown is open)


https://github.com/OpenBCI/OpenBCI_GUI/pull/778/commits/d9f74b3fdfd1570a6e2debacca258bae2860f730 - The GUI `Button` class was blocking access to Cp5 `Button` class, this commit renames all GUI Buttons to `Button_obci`, and it will be easier to convert them to cp5 buttons at another time.