### PR TITLE
add bufferedstack and make data stream look smooth

### DIFF
--- a/OpenBCI_GUI/BoardBrainflow.pde
+++ b/OpenBCI_GUI/BoardBrainflow.pde
@@ -19,6 +19,14 @@ abstract class BoardBrainFlow extends Board {
      */
     abstract protected BrainFlowInputParams getParams();
     abstract public BoardIds getBoardId();
+
+    public BoardBrainFlow (int fps, int samplingRate) {
+        super(fps, samplingRate);
+    }
+
+    public BoardBrainFlow () {
+        super();
+    }
     
     @Override
     public boolean initializeInternal() {

--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -53,11 +53,14 @@ static class BoardCytonConstants {
 
 class BoardCytonSerial extends BoardCyton {
     public BoardCytonSerial() {
-        super();
+        // todo[brainflow] switch between bufferedstack and fixedstack
+        super(30, 250);
     }
 
     public BoardCytonSerial(String serialPort) {
-        super();
+        // todo[brainflow] switch between bufferedstack and fixedstack
+        super(30, 250); // use bufferedstack
+        //super(); // use fixedstack
         this.serialPort = serialPort;
     }
 
@@ -69,11 +72,13 @@ class BoardCytonSerial extends BoardCyton {
 
 class BoardCytonSerialDaisy extends BoardCyton {
     public BoardCytonSerialDaisy() {
-        super();
+        // todo[brainflow] switch between bufferedstack and fixedstack
+        super(30, 125);
     }
 
     public BoardCytonSerialDaisy(String serialPort) {
-        super();
+        // todo[brainflow] switch between bufferedstack and fixedstack
+        super(30, 125);
         this.serialPort = serialPort;
     }
 
@@ -179,7 +184,15 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
 
     public BoardCyton() {
         super();
+        isCheckingImpedance = new boolean[getNumEXGChannels()];
+        Arrays.fill(isCheckingImpedance, false);
 
+        // The command 'd' is automatically sent by brainflow on prepare_session
+        currentADS1299Settings = new CytonDefaultSettings(this);
+    }
+
+    public BoardCyton(int fps, int samplingRate) {
+        super(fps, samplingRate);
         isCheckingImpedance = new boolean[getNumEXGChannels()];
         Arrays.fill(isCheckingImpedance, false);
 

--- a/OpenBCI_GUI/BoardNull.pde
+++ b/OpenBCI_GUI/BoardNull.pde
@@ -4,6 +4,10 @@
  */
 class BoardNull extends Board {
 
+    public BoardNull() {
+        super();
+    }
+
     @Override
     public boolean initializeInternal() {
         return true;

--- a/OpenBCI_GUI/BoardSynthetic.pde
+++ b/OpenBCI_GUI/BoardSynthetic.pde
@@ -23,6 +23,7 @@ class BoardSynthetic extends Board implements AccelerometerCapableBoard {
     private int accelSynthTime;
 
     public BoardSynthetic() {    
+        super();
         totalChannels = 0;
         sampleNumberChannel = totalChannels++;
         exgChannels = range(totalChannels, totalChannels + nchan);

--- a/OpenBCI_GUI/FixedStack.pde
+++ b/OpenBCI_GUI/FixedStack.pde
@@ -1,8 +1,9 @@
 import java.util.Stack;
-
+import java.util.concurrent.locks.ReentrantLock;
 
 public class FixedStack<T> extends Stack<T> {
-    private int maxSize;
+
+    protected int maxSize;
 
     public FixedStack(int size) {
         super();
@@ -31,5 +32,103 @@ public class FixedStack<T> extends Stack<T> {
             this.remove(0);
         }
         return super.push(object);
+    }
+}
+
+public class BufferedStack<T> extends FixedStack<T> implements Runnable {
+
+    // idea-  push to internalStack when user calls push
+    // pop from main stack and push to the main stack in another thread with timeout
+    private FixedStack<T> internalStack;
+    private int fps;
+    private int samplingRate;
+    private volatile boolean keepAlive;
+    private ReentrantLock mutex = new ReentrantLock();
+
+    public BufferedStack(int fps, int samplingRate, int size) {
+        super(size);
+        this.fps = fps;
+        this.samplingRate = samplingRate;
+        keepAlive = true;
+        internalStack = new FixedStack<T>(size);
+    }
+
+    public BufferedStack(int fps, int samplingRate) {
+        this(fps, samplingRate, 1000);
+    }
+
+    public BufferedStack(int samplingRate) {
+        this(25, samplingRate, 1000);
+    }
+
+    @Override
+    public void fill(T object) {
+        List<T> data = new ArrayList<T>();
+        for (int i = 0; i < maxSize; i++) {
+            data.add (object);
+        }
+
+        this.addAll(data);
+        internalStack.addAll(data);
+    }
+
+    @Override
+    public T push(T object) {
+        while (internalStack.size() >= maxSize) {
+            internalStack.remove(0);
+        }
+        return internalStack.push(object);
+    }
+
+    @Override
+    public void run() {
+        int sleepTime = 1000 / fps;
+        int packagesPerFrame = (samplingRate * fps) / 1000;
+        while (keepAlive) {
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                return;
+            }
+            List<T> data = internalStack.subList(0, packagesPerFrame);
+            // need to sync write and read to\from this buffer
+            mutex.lock();
+            this.removeRange(0, data.size());
+            this.addAll(data);
+            mutex.unlock();
+        }
+    }
+
+    @Override
+    public T pop()
+    {
+        mutex.lock();
+        T val = super.pop();
+        mutex.unlock();
+        return val;
+    }
+
+    @Override
+    public int size()
+    {
+        mutex.lock();
+        int size = super.size();
+        mutex.unlock();
+        return size;
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        mutex.lock();
+        List<T> res = super.subList(fromIndex, toIndex);
+        mutex.unlock();
+        List<T> cloned = new ArrayList(res);
+        return cloned;
+    }
+
+    // can be done in finalize but its not good
+    public void stop() {
+        keepAlive = false;
     }
 }

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -623,6 +623,7 @@ int getNfftSafe() {
         case 1600:
             return 2048;
         case 125:
+            return 128;
         case 200:
         case 250:
         default:


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

@retiutut Can you add UI controller to turn it off and on? We will need to pass value to Cyton constructor and call 

```
super(30, 250)
```
to make data stream "smooth" and call
```
super()
``` 
by default to plot real data

Also it would be great if you both test it, I've tested it on windows and set small and big latency for FTDI buffer to check.

Solution here is not perfect but its simple and does the job I think.