### PR TITLE
When channel disabled, turn off bias and srb2

### DIFF
--- a/OpenBCI_GUI/ADS1299SettingsBoard.pde
+++ b/OpenBCI_GUI/ADS1299SettingsBoard.pde
@@ -166,6 +166,9 @@ class ADS1299Settings {
     protected Board board;
     protected ADS1299SettingsBoard settingsBoard;
 
+    private Bias[] previousBias;
+    private Srb2[] previousSrb2; 
+
     ADS1299Settings(Board theBoard) {
         board = theBoard;
         settingsBoard = (ADS1299SettingsBoard)theBoard;
@@ -192,6 +195,30 @@ class ADS1299Settings {
 
         srb1 = new Srb1[channelCount];
         Arrays.fill(srb1, Srb1.DISCONNECT);
+
+        previousBias = bias.clone();
+        previousSrb2 = srb2.clone();
+    }
+
+    public boolean isChannelActive(int chan) {
+        return powerDown[chan] == PowerDown.ON;
+    }
+
+    public void setChannelActive(int chan, boolean active) {
+        if (active) {
+            bias[chan] = previousBias[chan];
+            srb2[chan] = previousSrb2[chan];
+
+        } else {
+            previousBias[chan] = bias[chan];
+            previousSrb2[chan] = srb2[chan];
+
+            bias[chan] = Bias.NO_INCLUDE;
+            srb2[chan] = Srb2.DISCONNECT;
+        }
+
+        powerDown[chan] = active ? PowerDown.ON : PowerDown.OFF;
+        commit(chan);
     }
 
     public void commit(int chan) {

--- a/OpenBCI_GUI/ADS1299SettingsController.pde
+++ b/OpenBCI_GUI/ADS1299SettingsController.pde
@@ -34,7 +34,32 @@ class ADS1299SettingsController{
             srb2Buttons[i].setString(boardSettings.srb2[i].getName());
             srb1Buttons[i].setString(boardSettings.srb1[i].getName());
 
-            
+            // grey out buttons when the channel is not active
+            if (boardSettings.isChannelActive(i)) {
+                gainButtons[i].setColorNotPressed(colorNotPressed);
+                inputTypeButtons[i].setColorNotPressed(colorNotPressed);
+                biasButtons[i].setColorNotPressed(colorNotPressed);
+                srb2Buttons[i].setColorNotPressed(colorNotPressed);
+                srb1Buttons[i].setColorNotPressed(colorNotPressed);
+
+                gainButtons[i].setIgnoreHover(false);
+                inputTypeButtons[i].setIgnoreHover(false);
+                biasButtons[i].setIgnoreHover(false);
+                srb2Buttons[i].setIgnoreHover(false);
+                srb1Buttons[i].setIgnoreHover(false);
+            } else {
+                gainButtons[i].setColorNotPressed(color(128));
+                inputTypeButtons[i].setColorNotPressed(color(128));
+                biasButtons[i].setColorNotPressed(color(128));
+                srb2Buttons[i].setColorNotPressed(color(128));
+                srb1Buttons[i].setColorNotPressed(color(128));
+
+                gainButtons[i].setIgnoreHover(true);
+                inputTypeButtons[i].setIgnoreHover(true);
+                biasButtons[i].setIgnoreHover(true);
+                srb2Buttons[i].setIgnoreHover(true);
+                srb1Buttons[i].setIgnoreHover(true);
+            }
         }
     }
 
@@ -54,33 +79,6 @@ class ADS1299SettingsController{
                 biasButtons[i].draw();
                 srb2Buttons[i].draw();
                 srb1Buttons[i].draw();
-
-                // grey out buttons when the channel is not active
-                if (boardSettings.isChannelActive(i)) {
-                    gainButtons[i].setColorNotPressed(colorNotPressed);
-                    inputTypeButtons[i].setColorNotPressed(colorNotPressed);
-                    biasButtons[i].setColorNotPressed(colorNotPressed);
-                    srb2Buttons[i].setColorNotPressed(colorNotPressed);
-                    srb1Buttons[i].setColorNotPressed(colorNotPressed);
-
-                    gainButtons[i].setIgnoreHover(false);
-                    inputTypeButtons[i].setIgnoreHover(false);
-                    biasButtons[i].setIgnoreHover(false);
-                    srb2Buttons[i].setIgnoreHover(false);
-                    srb1Buttons[i].setIgnoreHover(false);
-                } else {
-                    gainButtons[i].setColorNotPressed(color(128));
-                    inputTypeButtons[i].setColorNotPressed(color(128));
-                    biasButtons[i].setColorNotPressed(color(128));
-                    srb2Buttons[i].setColorNotPressed(color(128));
-                    srb1Buttons[i].setColorNotPressed(color(128));
-
-                    gainButtons[i].setIgnoreHover(true);
-                    inputTypeButtons[i].setIgnoreHover(true);
-                    biasButtons[i].setIgnoreHover(true);
-                    srb2Buttons[i].setIgnoreHover(true);
-                    srb1Buttons[i].setIgnoreHover(true);
-                }
             }
 
             //draw column headers for channel settings behind EEG graph

--- a/OpenBCI_GUI/ADS1299SettingsController.pde
+++ b/OpenBCI_GUI/ADS1299SettingsController.pde
@@ -1,18 +1,18 @@
 
 class ADS1299SettingsController{
 
-    boolean isVisible = false;
-    int x, y, w, h;
+    private boolean isVisible = false;
+    private int x, y, w, h;
 
-    int spaceBetweenButtons = 5; //space between buttons
+    private int spaceBetweenButtons = 5; //space between buttons
 
-    Button_obci[] gainButtons;
-    Button_obci[] inputTypeButtons;
-    Button_obci[] biasButtons;
-    Button_obci[] srb2Buttons;
-    Button_obci[] srb1Buttons;
+    private Button_obci[] gainButtons;
+    private Button_obci[] inputTypeButtons;
+    private Button_obci[] biasButtons;
+    private Button_obci[] srb2Buttons;
+    private Button_obci[] srb1Buttons;
 
-    ADS1299Settings boardSettings;
+    private ADS1299Settings boardSettings;
 
     ADS1299SettingsController(int _x, int _y, int _w, int _h, int _channelBarHeight){
         x = _x;
@@ -33,6 +33,8 @@ class ADS1299SettingsController{
             biasButtons[i].setString(boardSettings.bias[i].getName());
             srb2Buttons[i].setString(boardSettings.srb2[i].getName());
             srb1Buttons[i].setString(boardSettings.srb1[i].getName());
+
+            
         }
     }
 
@@ -52,6 +54,33 @@ class ADS1299SettingsController{
                 biasButtons[i].draw();
                 srb2Buttons[i].draw();
                 srb1Buttons[i].draw();
+
+                // grey out buttons when the channel is not active
+                if (boardSettings.isChannelActive(i)) {
+                    gainButtons[i].setColorNotPressed(colorNotPressed);
+                    inputTypeButtons[i].setColorNotPressed(colorNotPressed);
+                    biasButtons[i].setColorNotPressed(colorNotPressed);
+                    srb2Buttons[i].setColorNotPressed(colorNotPressed);
+                    srb1Buttons[i].setColorNotPressed(colorNotPressed);
+
+                    gainButtons[i].setIgnoreHover(false);
+                    inputTypeButtons[i].setIgnoreHover(false);
+                    biasButtons[i].setIgnoreHover(false);
+                    srb2Buttons[i].setIgnoreHover(false);
+                    srb1Buttons[i].setIgnoreHover(false);
+                } else {
+                    gainButtons[i].setColorNotPressed(color(128));
+                    inputTypeButtons[i].setColorNotPressed(color(128));
+                    biasButtons[i].setColorNotPressed(color(128));
+                    srb2Buttons[i].setColorNotPressed(color(128));
+                    srb1Buttons[i].setColorNotPressed(color(128));
+
+                    gainButtons[i].setIgnoreHover(true);
+                    inputTypeButtons[i].setIgnoreHover(true);
+                    biasButtons[i].setIgnoreHover(true);
+                    srb2Buttons[i].setIgnoreHover(true);
+                    srb1Buttons[i].setIgnoreHover(true);
+                }
             }
 
             //draw column headers for channel settings behind EEG graph
@@ -141,25 +170,30 @@ class ADS1299SettingsController{
     public void mousePressed(){
         if (isVisible) {
             for (int i = 0; i < currentBoard.getNumEXGChannels(); i++) {
-                if(gainButtons[i].isMouseHere()) {
-                    gainButtons[i].wasPressed = true;
-                    gainButtons[i].isActive = true;                    
-                }
-                if(inputTypeButtons[i].isMouseHere()) {
-                    inputTypeButtons[i].wasPressed = true;
-                    inputTypeButtons[i].isActive = true;                    
-                }
-                if(biasButtons[i].isMouseHere()) {
-                    biasButtons[i].wasPressed = true;
-                    biasButtons[i].isActive = true;                    
-                }
-                if(srb2Buttons[i].isMouseHere()) {
-                    srb2Buttons[i].wasPressed = true;
-                    srb2Buttons[i].isActive = true;                    
-                }
-                if(srb1Buttons[i].isMouseHere()) {
-                    srb1Buttons[i].wasPressed = true;
-                    srb1Buttons[i].isActive = true;                    
+
+                // buttons only work if the channel is active
+                if (boardSettings.isChannelActive(i)) {
+
+                    if(gainButtons[i].isMouseHere()) {
+                        gainButtons[i].wasPressed = true;
+                        gainButtons[i].isActive = true;                    
+                    }
+                    if(inputTypeButtons[i].isMouseHere()) {
+                        inputTypeButtons[i].wasPressed = true;
+                        inputTypeButtons[i].isActive = true;                    
+                    }
+                    if(biasButtons[i].isMouseHere()) {
+                        biasButtons[i].wasPressed = true;
+                        biasButtons[i].isActive = true;                    
+                    }
+                    if(srb2Buttons[i].isMouseHere()) {
+                        srb2Buttons[i].wasPressed = true;
+                        srb2Buttons[i].isActive = true;                    
+                    }
+                    if(srb1Buttons[i].isMouseHere()) {
+                        srb1Buttons[i].wasPressed = true;
+                        srb1Buttons[i].isActive = true;                    
+                    }
                 }
             }
         }

--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -210,13 +210,12 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
 
     @Override
     public void setEXGChannelActive(int channelIndex, boolean active) {
-        currentADS1299Settings.powerDown[channelIndex] = active ? PowerDown.ON : PowerDown.OFF;
-        currentADS1299Settings.commit(channelIndex);
+        currentADS1299Settings.setChannelActive(channelIndex, active);
     }
-
+    
     @Override
     public boolean isEXGChannelActive(int channelIndex) {
-        return currentADS1299Settings.powerDown[channelIndex] == PowerDown.ON;
+        return currentADS1299Settings.isChannelActive(channelIndex);
     }
 
     @Override

--- a/OpenBCI_GUI/BoardNovaXR.pde
+++ b/OpenBCI_GUI/BoardNovaXR.pde
@@ -187,13 +187,12 @@ implements ImpedanceSettingsBoard, EDACapableBoard, PPGCapableBoard, ADS1299Sett
 
     @Override
     public void setEXGChannelActive(int channelIndex, boolean active) {
-        currentADS1299Settings.powerDown[channelIndex] = active ? PowerDown.ON : PowerDown.OFF;
-        currentADS1299Settings.commit(channelIndex);
+        currentADS1299Settings.setChannelActive(channelIndex, active);
     }
     
     @Override
     public boolean isEXGChannelActive(int channelIndex) {
-        return currentADS1299Settings.powerDown[channelIndex] == PowerDown.ON;
+        return currentADS1299Settings.isChannelActive(channelIndex);
     }
     
     @Override

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
         <key>CFBundleShortVersionString</key>
         <string>4</string>
         <key>CFBundleVersion</key>
-        <string>5.0.0-alpha.7</string>
+        <string>5.0.0-alpha.8</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -487,10 +487,6 @@ class Button_obci {
         return but_txt;
     }
 
-    public void setCurrentColor(color _color){
-        currentColor = _color;
-    }
-
     public void setColorPressed(color _color) {
         color_pressed = _color;
     }

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -61,7 +61,7 @@ import com.fazecast.jSerialComm.*; //Helps distinguish serial ports on Windows
 //                       Global Variables & Instances
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v5.0.0-alpha.7";
+String localGUIVersionString = "v5.0.0-alpha.8";
 String localGUIVersionDate = "May 2020";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiVersionCheckHasOccured = false;

--- a/OpenBCI_GUI/W_TimeSeries.pde
+++ b/OpenBCI_GUI/W_TimeSeries.pde
@@ -239,12 +239,11 @@ class W_timeSeries extends Widget {
             if (!this.dropdownIsActive) {
                 adsSettingsController.mousePressed();
             }
-        } else {
-            for(int i = 0; i < channelBars.length; i++) {
-                channelBars[i].mousePressed();
-            }
         }
 
+        for(int i = 0; i < channelBars.length; i++) {
+            channelBars[i].mousePressed();
+        }
     }
     
     void mouseReleased() {
@@ -260,10 +259,10 @@ class W_timeSeries extends Widget {
 
         if(adsSettingsController != null && adsSettingsController.isVisible) {
             adsSettingsController.mouseReleased();
-        } else {
-            for(int i = 0; i < channelBars.length; i++) {
-                channelBars[i].mouseReleased();
-            }
+        } 
+        
+        for(int i = 0; i < channelBars.length; i++) {
+            channelBars[i].mouseReleased();
         }
     }
 


### PR DESCRIPTION
When disabling a channel:

- remember previous buttons settings
- dis-include bias
- disconnect srb2
- grey-out/disable all settings buttons for that channel.

When re-enabling channel:

- restore previous button settings
- re-enable all buttons for that channel

Bonus:

- Make it so you can press the channel on/off buttons when the settings controller is open.