### PR TITLE
Fix extreme slowness when selecting Cyton Serial data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improved Playback Mode and Time Series
 * Refactored GUI data flow
 * Add Travis and Appveyor CI tests and builds for all OS
+* Cyton Port manual selection only displays serial ports with a dongle connected.
 
 ### Bug Fixes
 * Remove OpenBCI Hub #665 #669 #708

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1462,7 +1462,7 @@ class BLEBox {
         
     }
 
-    private void refreshPortListGanglion() {
+    private void refreshGanglionBLEList() {
         output("BLE Devices Refreshing");
         bleList.items.clear();
         

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1468,6 +1468,8 @@ class BLEBox {
         
         Thread thread = new Thread(){
             public void run(){
+                refreshBLE.setString("SEARCHING...");
+                bleIsRefreshing = true;
                 final String comPort = getBLED112Port();
                 if (comPort != null) {
                     try {
@@ -1484,6 +1486,8 @@ class BLEBox {
                 } else {
                     outputError("No BLED112 Dongle Found");
                 }
+                refreshBLE.setString("START SEARCH");
+                bleIsRefreshing = false;
             }
         };
 

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1395,7 +1395,7 @@ class ComPortBox {
         LinkedList<String> results = new LinkedList<String>();
         for (int i = 0; i < comPorts.length; i++) {
             if (comPorts[i].toString().equals(name)) {
-                String found = "";
+                String found = "(Cyton) ";
                 if (isMac() || isLinux()) found += "/dev/";
                 found += comPorts[i].getSystemPortName().toString();
                 println("ControlPanel: Found Cyton Dongle on COM port: " + found);

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -163,7 +163,7 @@ public void controlEvent(ControlEvent theEvent) {
 
     if (theEvent.isFrom("serialList")) {
         Map bob = ((MenuList)theEvent.getController()).getItem(int(theEvent.getValue()));
-        openBCI_portName = (String)bob.get("headline");
+        openBCI_portName = (String)bob.get("subline");
         output("OpenBCI Port Name = " + openBCI_portName);
     }
 
@@ -1378,7 +1378,7 @@ class ComPortBox {
                 String name = "FT231X USB UART";
                 LinkedList<String> comPorts = getCytonComPorts();
                 for (String comPort : comPorts) {
-                    serialList.addItem(makeItem(comPort));
+                    serialList.addItem(makeItem("(Cyton) " + comPort, comPort, ""));
                 }
                 serialList.updateMenu();
 

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1375,7 +1375,6 @@ class ComPortBox {
             public void run(){
                 refreshPort.setString("SEARCHING...");
 
-                String name = "FT231X USB UART";
                 LinkedList<String> comPorts = getCytonComPorts();
                 for (String comPort : comPorts) {
                     serialList.addItem(makeItem("(Cyton) " + comPort, comPort, ""));

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -630,27 +630,29 @@ class ControlPanel {
     private void refreshPortListGanglion() {
         output("BLE Devices Refreshing");
         bleList.items.clear();
-        final String comPort = getBLED112Port();
-        if (comPort != null) {
-            Thread thread = new Thread(){
-                public void run(){
+        
+        Thread thread = new Thread(){
+            public void run(){
+                final String comPort = getBLED112Port();
+                if (comPort != null) {
                     try {
                         BLEMACAddrMap = GUIHelper.scan_for_ganglions (comPort, 3);
                         for (Map.Entry<String, String> entry : BLEMACAddrMap.entrySet ())
                         {
-                            bleList.addItem(makeItem(entry.getKey()));
+                            bleList.addItem(makeItem(entry.getKey(), comPort, ""));
                             bleList.updateMenu();
                         }
                     } catch (GanglionError e)
                     {
                         e.printStackTrace();
                     }
+                } else {
+                    outputError("No BLED112 Dongle Found");
                 }
-            };
-            thread.start();
-        } else {
-            outputError("No BLED112 Dongle Found");
-        }
+            }
+        };
+
+        thread.start();
     }
 
     private String getBLED112Port() {

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1395,7 +1395,7 @@ class ComPortBox {
         LinkedList<String> results = new LinkedList<String>();
         for (int i = 0; i < comPorts.length; i++) {
             if (comPorts[i].toString().equals(name)) {
-                String found = "(Cyton) ";
+                String found = "";
                 if (isMac() || isLinux()) found += "/dev/";
                 found += comPorts[i].getSystemPortName().toString();
                 println("ControlPanel: Found Cyton Dongle on COM port: " + found);

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
         <key>CFBundleShortVersionString</key>
         <string>4</string>
         <key>CFBundleVersion</key>
-        <string>5.0.0-alpha.8</string>
+        <string>5.0.0-alpha.9</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -518,10 +518,11 @@ void initSystem() {
             }
             else {
                 // todo[brainflow] temp hardcode
-                String ganglionName = (String)cp5.get(MenuList.class, "bleList").getItem(bleList.activeItem).get("headline");
+                String ganglionName = (String)(bleList.getItem(bleList.activeItem).get("headline"));
+                String ganglionPort = (String)(bleList.getItem(bleList.activeItem).get("subline"));
                 String ganglionMac = BLEMACAddrMap.get(ganglionName);
                 println("MAC address for Ganglion is " + ganglionMac);
-                currentBoard = new BoardGanglionBLE(controlPanel.getBLED112Port(), ganglionMac);
+                currentBoard = new BoardGanglionBLE(ganglionPort, ganglionMac);
             }
             break;
         case DATASOURCE_NOVAXR:

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -61,7 +61,7 @@ import com.fazecast.jSerialComm.*; //Helps distinguish serial ports on Windows
 //                       Global Variables & Instances
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v5.0.0-alpha.8";
+String localGUIVersionString = "v5.0.0-alpha.9";
 String localGUIVersionDate = "May 2020";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiVersionCheckHasOccured = false;

--- a/OpenBCI_GUI/SoftwareSettings.pde
+++ b/OpenBCI_GUI/SoftwareSettings.pde
@@ -1113,18 +1113,7 @@ class SoftwareSettings {
 
     void initCheckPointFive() {
         //Prepare the data mode and version, if needed, to be printed at init checkpoint 5 below
-        String firmwareToPrint = "";
         String dataModeVersionToPrint = controlEventDataSource;
-        if (eegDataSource == DATASOURCE_CYTON) {
-            if (!settings.loadErrorCytonEvent) {
-                //todo get cyton firmware version if possible during Init
-                firmwareToPrint = " " + "FIX ME" + ")";
-            } else {
-                firmwareToPrint = "v.?)";
-            }
-            dataModeVersionToPrint = controlEventDataSource.replace(")", " ");
-            dataModeVersionToPrint += firmwareToPrint;
-        }
 
         //Output messages when Loading settings is complete
         if (chanNumError == false


### PR DESCRIPTION
SerialPort.getCommPorts() is very expensive, and was being run on the main thread on every update

- Avoid calling getCommPorts on main thread for ganglion
- Make cyton serial discovery just like ganglion and wifi:
   - Call it on a separate thread
   - Call it once when selecting the data source, do not call again until user presses button
- There was duplicate code between autoconnect and Cyton discovery. Make this code shared.