### PR TITLE
Restore widget dropdown labels

### DIFF
--- a/OpenBCI_GUI/Widget.pde
+++ b/OpenBCI_GUI/Widget.pde
@@ -184,6 +184,19 @@ class Widget{
 
     private void drawDropdowns(){
         cp5_widget.draw(); //this draws all cp5 elements... in this case, the scrollable lists that populate our dropdowns<>
+
+        //draw dropdown titles		
+        pushStyle();		
+        noStroke();		
+        textFont(h5);		
+        textSize(12);		
+        textAlign(CENTER, BOTTOM);		
+        fill(bgColor);		
+        for(int i = 0; i < dropdowns.size(); i++){		
+            int dropdownPos = dropdowns.size() - i;		
+            // text(dropdowns.get(i).title, x+w-(dropdownWidth*(dropdownPos+1))-(2*(dropdownPos+1))+dropdownWidth/2, y+(navH-2));		
+            text(dropdowns.get(i).title, x0+w0-(dropdownWidth*(dropdownPos))-(2*(dropdownPos+1))+dropdownWidth/2, y0+(navH-2));		
+        }
     }
 
     public void mouseDragged(){


### PR DESCRIPTION
Before:

![Screen Shot 2020-06-09 at 2 07 15 PM](https://user-images.githubusercontent.com/25914123/84190328-5bad0400-aa5c-11ea-84a0-6f0eb45e9eb5.png)


After:

![Screen Shot 2020-06-09 at 2 21 42 PM](https://user-images.githubusercontent.com/25914123/84190432-8c8d3900-aa5c-11ea-817f-b12ba578f0ad.png)
