### PR TITLE
Fix Spectrogram Timestamps with minus() instead of plus()

### DIFF
--- a/OpenBCI_GUI/W_Spectrogram.pde
+++ b/OpenBCI_GUI/W_Spectrogram.pde
@@ -404,7 +404,7 @@ class W_Spectrogram extends Widget {
         
         for (int i = 0; i <= numAxisTicks; i++) {
             long l = (long)(horizAxisLabel[i] * 60f);
-            LocalDateTime t = time.plus(l, ChronoUnit.SECONDS);
+            LocalDateTime t = time.minus(l, ChronoUnit.SECONDS);
             horizAxisLabelStrings.append(t.format(formatter));
         }
     }


### PR DESCRIPTION
Times were completely wrong, since time should be subtracted instead of added.

Fixed now.