### PR TITLE
cleanup code when resizing gui

### DIFF
--- a/OpenBCI_GUI/Containers.pde
+++ b/OpenBCI_GUI/Containers.pde
@@ -78,7 +78,6 @@ void drawContainers() {
 
     //alternative component listener function (line 177 - 187 frame.addComponentListener) for processing 3,
     if (widthOfLastScreen_C != width || heightOfLastScreen_C != height) {
-        println("OpenBCI_GUI: setup: RESIZED");
         setupContainers();
         //setupVizs(); //container extension example (more below)
         settings.widthOfLastScreen = width;

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -326,7 +326,6 @@ void delayedSetup() {
     frame.addComponentListener(new ComponentAdapter() {
         public void componentResized(ComponentEvent e) {
             if (e.getSource()==frame) {
-                println("OpenBCI_GUI: setup: RESIZED");
                 settings.screenHasBeenResized = true;
                 settings.timeOfLastScreenResize = millis();
                 // initializeGUI();
@@ -792,12 +791,9 @@ void systemUpdate() { // for updating data values and variables
     }
     if (systemMode == SYSTEMMODE_POSTINIT) {
         processNewData();
-
-        // gui.cc.update(); //update Channel Controller even when not updating certain parts of the GUI... (this is a bit messy...)
-
+        
         //alternative component listener function (line 177 - 187 frame.addComponentListener) for processing 3,
         if (settings.widthOfLastScreen != width || settings.heightOfLastScreen != height) {
-            println("OpenBCI_GUI: setup: RESIZED");
             settings.screenHasBeenResized = true;
             settings.timeOfLastScreenResize = millis();
             settings.widthOfLastScreen = width;
@@ -810,11 +806,6 @@ void systemUpdate() { // for updating data values and variables
             imposeMinimumGUIDimensions();
             topNav.screenHasBeenResized(width, height);
             wm.screenResized();
-        }
-        if (settings.screenHasBeenResized == true && (millis() - settings.timeOfLastScreenResize) > settings.reinitializeGUIdelay) {
-            settings.screenHasBeenResized = false;
-            println("systemUpdate: reinitializing GUI");
-            settings.timeOfGUIreinitialize = millis();
         }
 
         if (wm.isWMInitialized) {
@@ -860,22 +851,7 @@ void systemDraw() { //for drawing to the screen
             break;
         }
 
-        //wait 1 second for GUI to reinitialize
-        if ((millis() - settings.timeOfGUIreinitialize) > settings.reinitializeGUIdelay) {
-            // println("attempting to draw GUI...");
-            try {
-                // println("GUI DRAW!!! " + millis());
-                //draw GUI widgets (visible/invisible) using widget manager
-                wm.draw();
-            } catch (Exception e) {
-                println(e.getMessage());
-                settings.reinitializeGUIdelay = settings.reinitializeGUIdelay * 2;
-                println("OpenBCI_GUI: systemDraw: New GUI reinitialize delay = " + settings.reinitializeGUIdelay);
-            }
-        } else {
-            //reinitializing GUI after resize
-            println("OpenBCI_GUI: systemDraw: reinitializing GUI after resize... not drawing GUI");
-        }
+        wm.draw();
 
         drawContainers();
     } else { //systemMode != 10

--- a/OpenBCI_GUI/SoftwareSettings.pde
+++ b/OpenBCI_GUI/SoftwareSettings.pde
@@ -46,8 +46,6 @@ class SoftwareSettings {
     //for screen resizing
     boolean screenHasBeenResized = false;
     float timeOfLastScreenResize = 0;
-    float timeOfGUIreinitialize = 0;
-    int reinitializeGUIdelay = 125;
     int widthOfLastScreen = 0;
     int heightOfLastScreen = 0;
     //default layout variables

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -717,7 +717,6 @@ class W_Networking extends Widget {
         itemWidth = int(map(width, 1024, 1920, 100, 120)) - 4;
         
         int dropdownsItemsToShow = int((this.h0 * datatypeDropdownScaling) / (this.navH - 4));
-        println("Networking Data Types || show num dropdowns = " + dropdownsItemsToShow);
         int dropdownHeight = (dropdownsItemsToShow + 1) * (this.navH - 4);
         int maxDropdownHeight = (settings.nwDataTypesArray.length + 1) * (this.navH - 4);
         if (dropdownHeight > maxDropdownHeight) dropdownHeight = maxDropdownHeight;

--- a/OpenBCI_GUI/W_PulseSensor.pde
+++ b/OpenBCI_GUI/W_PulseSensor.pde
@@ -161,8 +161,6 @@ class W_PulseSensor extends Widget {
     void screenResized(){
         super.screenResized(); //calls the parent screenResized() method of Widget (DON'T REMOVE)
 
-        println("Pulse Sensor Widget -- Screen Resized.");
-
         setPulseWidgetVariables();
         analogModeButton.setPos((int)(x + 3), (int)(y + 3 - navHeight));
     }

--- a/OpenBCI_GUI/Widget.pde
+++ b/OpenBCI_GUI/Widget.pde
@@ -224,7 +224,6 @@ class Widget{
 
     private void resizeWidgetSelector() {
         int dropdownsItemsToShow = int((h0 * widgetDropdownScaling) / (navH - 4));
-        //println("Widget " + widgetTitle +  " || show num dropdowns = " + dropdownsItemsToShow);
         widgetSelectorHeight = (dropdownsItemsToShow + 1) * (navH - 4);
         if (wm != null) {
             int maxDropdownHeight = (wm.widgetOptions.size() + 1) * (navH - 4);


### PR DESCRIPTION
- Remove unnecessary code that stops drawing when resizing
- remove annoying printouts when resizing GUI which were also slowing things down.