### PR TITLE
Smoothing buffer was filling up to the max

### DIFF
--- a/OpenBCI_GUI/Buffer.pde
+++ b/OpenBCI_GUI/Buffer.pde
@@ -5,17 +5,17 @@ public class Buffer<T> extends LinkedList<T> {
 
     private int samplingRate;
     private int maxSize;
-    private Long msSinceLastCall;
+    private Long timeOfLastCallMS;
 
     Buffer(int samplingRate, int maxSize) {
         this.samplingRate = samplingRate;
         this.maxSize = maxSize;
-        msSinceLastCall = null;
+        timeOfLastCallMS = null;
     }
 
     Buffer(int samplingRate) {
-        // max delay smth like 2 seconds
-        this(samplingRate, samplingRate * 2);
+        // max delay 1 second
+        this(samplingRate, samplingRate /*max size*/);
     }
 
     public void addNewEntry(T object) {
@@ -30,11 +30,12 @@ public class Buffer<T> extends LinkedList<T> {
         long currentTime = millis();
         int numSamples = 0;
         // skip first call to set time
-        if (msSinceLastCall != null) {
-            double deltaTimeSeconds = (currentTime - msSinceLastCall.longValue()) / 1000.0;
-            numSamples = (int)(samplingRate * deltaTimeSeconds);
+        if (timeOfLastCallMS != null) {
+            float deltaTimeSeconds = (currentTime - timeOfLastCallMS.longValue()) / 1000.0;
+            // for safety, err on the side of delivering more samples (hence the use of ceil())
+            numSamples = ceil(samplingRate * deltaTimeSeconds);
         }
-        msSinceLastCall = currentTime;
+        timeOfLastCallMS = currentTime;
         // ensure that buffer is not bigger than maxSize
         if (this.size() > maxSize) {
             numSamples += this.size() - maxSize;


### PR DESCRIPTION
Conor was right. The smoothing buffer is quickly filling up to its max size and introducing a 2 second delay.

The fix is to use ceil() when calculating the number of samples to deliver, and err on the side of delivering more samples.