### PR TITLE
Fix AXR Playback mode inaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Update ChannelSelect Feature in Widget Class to show what channels are on or off
 * Improve Time Series y-axis autoscale performance
 
+### Bug Fixes
+* Exit session init when current board fails to initialize
+
 # v5.0.1
 
 ### Improvements

--- a/OpenBCI_GUI/BoardAuraXR.pde
+++ b/OpenBCI_GUI/BoardAuraXR.pde
@@ -3,7 +3,7 @@ import brainflow.*;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-final boolean auraXREnabled = false;
+final boolean auraXREnabled = true;
 
 interface AuraXRSettingsEnum {
     public String getName();

--- a/OpenBCI_GUI/BoardAuraXR.pde
+++ b/OpenBCI_GUI/BoardAuraXR.pde
@@ -3,7 +3,7 @@ import brainflow.*;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-final boolean auraXREnabled = true;
+final boolean auraXREnabled = false;
 
 interface AuraXRSettingsEnum {
     public String getName();

--- a/OpenBCI_GUI/DataSourcePlayback.pde
+++ b/OpenBCI_GUI/DataSourcePlayback.pde
@@ -360,7 +360,7 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
     public Integer getBatteryChannel() {
         if (batteryChannelCache == null && underlyingBoard instanceof BatteryInfoCapableBoard) {
             try {
-                batteryChannelCache = BoardShim.get_battery_channel(BoardIds.AURAXR_BOARD.get_code());
+                batteryChannelCache = BoardShim.get_battery_channel(((BoardBrainFlow)underlyingBoard).getBoardIdInt());
             } catch (BrainFlowError e) {
                 e.printStackTrace();
             }

--- a/OpenBCI_GUI/DataSourcePlayback.pde
+++ b/OpenBCI_GUI/DataSourcePlayback.pde
@@ -1,9 +1,10 @@
-class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, AnalogCapableBoard, DigitalCapableBoard, EDACapableBoard, PPGCapableBoard, FileBoard  {
+class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, AnalogCapableBoard, DigitalCapableBoard, EDACapableBoard, PPGCapableBoard, BatteryInfoCapableBoard, FileBoard  {
     private String playbackFilePath;
     private ArrayList<double[]> rawData;
     private int currentSample;
     private int timeOfLastUpdateMS;
     private String underlyingClassName;
+    private Integer batteryChannelCache = null;
 
     private boolean initialized = false;
     private boolean streaming = false;
@@ -353,6 +354,19 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
         }
 
         return new int[0];
+    }
+
+    @Override
+    public Integer getBatteryChannel() {
+        if (batteryChannelCache == null && underlyingBoard instanceof BatteryInfoCapableBoard) {
+            try {
+                batteryChannelCache = BoardShim.get_battery_channel(BoardIds.AURAXR_BOARD.get_code());
+            } catch (BrainFlowError e) {
+                e.printStackTrace();
+            }
+        }
+
+        return batteryChannelCache;
     }
 
     @Override

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -537,31 +537,15 @@ void initSystem() {
 
     if (abandonInit) {
         haltSystem();
-        println("Failed to connect to data source... 1");
-        outputError("Failed to connect to data source fail point 1");
+        outputError("Failed to initialize board. Please check that the board is on and has power.");
+        controlPanel.open();
+        return;
     } else {
-        //initilize the GUI
+        //initilize the secondary topnav and all applicable widgets
         topNav.initSecondaryNav();
-
         wm = new WidgetManager(this);
-
-        if (!abandonInit) {
-            nextPlayback_millis = millis(); //used for synthesizeData and readFromFile.  This restarts the clock that keeps the playback at the right pace.
-
-            systemMode = SYSTEMMODE_POSTINIT; //tell system it's ok to leave control panel and start interfacing GUI
-
-            if (!abandonInit) {
-                controlPanel.close();
-            } else {
-                haltSystem();
-                println("Failed to connect to data source... 2");
-                // output("Failed to connect to data source...");
-            }
-        } else {
-            haltSystem();
-            println("Failed to connect to data source... 3");
-            // output("Failed to connect to data source...");
-        }
+        nextPlayback_millis = millis(); //used for synthesizeData and readFromFile.  This restarts the clock that keeps the playback at the right pace.
+        systemMode = SYSTEMMODE_POSTINIT; //tell system it's ok to leave control panel and start interfacing GUI
     }
 
     verbosePrint("OpenBCI_GUI: initSystem: -- Init 4 -- " + millis());


### PR DESCRIPTION
The issue is with BatteryInfo in the Aux widget when trying to playback CSV file (Cyton, Ganglion, or AXR). Was throwing this error:

```
java.lang.ClassCastException: OpenBCI_GUI$DataSourcePlayback cannot be cast to OpenBCI_GUI$BatteryInfoCapableBoard
        at OpenBCI_GUI$W_NovaAux.<init>(OpenBCI_GUI.java:21828)
```

Here is an initial fix. Maybe there is a better way... Open to suggestions.


This PR also addresses an issue where BrainFlow throws an error when trying to connect to board, but GUI shows "success" at the bottom. Now, it does a hard `return` and exits session init process and returns UI back to control panel.