### PR TITLE
Fix getFrameData() for Playback/SD Board Classes Fixes #906

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix drawing error on lower resolution screens #900
 * Save BDF start time in 24hr format instead of 12hr #904
 * Fix TimeSeries Unfiltered Networking Output #891 #889
+* Fix TimeSeries Networking Output when using Playback Mode w/ GUI or SD file #906
 
 # v5.0.1
 

--- a/OpenBCI_GUI/DataSourcePlayback.pde
+++ b/OpenBCI_GUI/DataSourcePlayback.pde
@@ -5,6 +5,7 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
     private int timeOfLastUpdateMS;
     private String underlyingClassName;
     private Integer batteryChannelCache = null;
+    private int numNewSamplesThisFrame;
 
     private boolean initialized = false;
     private boolean streaming = false;
@@ -130,7 +131,7 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
         float sampleRateMS = getSampleRate() / 1000.f;
 
         int timeElapsedMS = millis() - timeOfLastUpdateMS;
-        int numNewSamplesThisFrame = floor(timeElapsedMS * sampleRateMS);
+        numNewSamplesThisFrame = floor(timeElapsedMS * sampleRateMS);
 
         // account for the fact that each update will not coincide with a sample exactly. 
         // to keep the streaming rate accurate, we increment the time of last update
@@ -225,8 +226,14 @@ class DataSourcePlayback implements DataSource, AccelerometerCapableBoard, Analo
 
     @Override
     public double[][] getFrameData() {
-        // empty data (for now?)
-        return new double[getTotalChannelCount()][0];
+        double[][] array = new double[getTotalChannelCount()][numNewSamplesThisFrame];
+        List<double[]> list = getData(numNewSamplesThisFrame);
+        for (int i = 0; i < numNewSamplesThisFrame; i++) {
+            for (int j = 0; j < getTotalChannelCount(); j++) {
+                array[j][i] = list.get(i)[j];
+            }
+        }
+        return array;
     }
 
     @Override

--- a/OpenBCI_GUI/DataSourceSDCard.pde
+++ b/OpenBCI_GUI/DataSourceSDCard.pde
@@ -9,6 +9,7 @@ class DataSourceSDCard implements DataSource, FileBoard, AccelerometerCapableBoa
     private double startTime;
     private int counter;
     private int currentSample;
+    private int numNewSamplesThisFrame;
     private int timeOfLastUpdateMS;
     private double accel_x;
     private double accel_y;
@@ -126,7 +127,7 @@ class DataSourceSDCard implements DataSource, FileBoard, AccelerometerCapableBoa
 
         float sampleRateMS = getSampleRate() / 1000.f;
         int timeElapsedMS = millis() - timeOfLastUpdateMS;
-        int numNewSamplesThisFrame = floor(timeElapsedMS * sampleRateMS);
+        numNewSamplesThisFrame = floor(timeElapsedMS * sampleRateMS);
 
         // account for the fact that each update will not coincide with a sample exactly. 
         // to keep the streaming rate accurate, we increment the time of last update
@@ -201,8 +202,14 @@ class DataSourceSDCard implements DataSource, FileBoard, AccelerometerCapableBoa
 
     @Override
     public double[][] getFrameData() {
-        // empty data (for now?)
-        return new double[getTotalChannelCount()][0];
+        double[][] array = new double[getTotalChannelCount()][numNewSamplesThisFrame];
+        List<double[]> list = getData(numNewSamplesThisFrame);
+        for (int i = 0; i < numNewSamplesThisFrame; i++) {
+            for (int j = 0; j < getTotalChannelCount(); j++) {
+                array[j][i] = list.get(i)[j];
+            }
+        }
+        return array;
     }
 
     @Override

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -245,22 +245,28 @@ class W_Networking extends Widget {
             previousCP5State = cp5ElementsAreActive;
         }
 
-        accumulateNewData();
+        if (currentBoard.isStreaming()) {
+            accumulateNewData();
 
-        checkIfEnoughDataToSend();
+            checkIfEnoughDataToSend();
+        }
     }
 
     private void accumulateNewData() {
         // accumulate data
         double[][] newData = currentBoard.getFrameData();
         int[] exgChannels = currentBoard.getEXGChannels();
-        for (int iSample = 0; iSample < newData[0].length; iSample ++) {
-            
+        
+        if (newData[exgChannels[0]].length == 0) {
+            return;
+        }
+
+        for (int iSample = 0; iSample < newData[exgChannels[0]].length; iSample++) {
             double[] sample = new double[exgChannels.length];
             for (int iChan = 0; iChan < exgChannels.length; iChan++) {
                 sample[iChan] = newData[exgChannels[iChan]][iSample];
+                //println("CHAN== "+iChan+"  || SAMPLE== "+iSample+"   DATA=="+sample[iChan]);
             }
-
             dataAccumulationQueue.add(sample);
         }
     }


### PR DESCRIPTION
getFrameData() was returning empty data for GUI-made recording playback and Cyton SD card playback... now it returns valid data and Fixes #906