### PR TITLE
Enable streaming board to use Cyton Daisy source

### DIFF
--- a/OpenBCI_GUI/BoardBrainFlowStreaming.pde
+++ b/OpenBCI_GUI/BoardBrainFlowStreaming.pde
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.tuple.Pair;
 public enum BrainFlowStreaming_Boards
 {
     CYTON("Cyton", BoardIds.CYTON_BOARD),
+    CYTONDAISY("CytonDaisy", BoardIds.CYTON_DAISY_BOARD),
     GANGLION("Ganglion", BoardIds.GANGLION_BOARD),
     GALEA("Galea", BoardIds.GALEA_BOARD),
     SYNTHETIC("Synthetic", BoardIds.SYNTHETIC_BOARD);
@@ -124,6 +125,9 @@ class BoardBrainFlowStreaming extends BoardBrainFlow implements AccelerometerCap
 
     @Override
     protected PacketLossTracker setupPacketLossTracker() {
+        if (masterBoardId == BoardIds.CYTON_DAISY_BOARD) {
+                return new PacketLossTrackerCytonSerialDaisy(getSampleIndexChannel(), getTimestampChannel());
+        }
         final int minSampleIndex = 0;
         final int maxSampleIndex = 255;
         return new PacketLossTracker(getSampleIndexChannel(), getTimestampChannel(),


### PR DESCRIPTION
This change enables the Cyton Daisy source when using Streaming board.