### PR TITLE
2021 pulse sensor update - GUI v5.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ application.*
 *.autosave
 .vscode/*
 temp/*
+libBoardController.so
+libDataHandler.so
+libGanglionLib.so
+libGanglionScan.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # v5.0.3
 
 ### Improvements
+* Increase sampling rate for Pulse data output in Networking Widget
 
 ### Bug Fixes
+* Fix Pulse LSL output error #943
 * Fix Accel/Aux UDP output #944
 * Fix Expert Mode unplanned keyboard shortcuts crash GUI #941
 

--- a/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
+++ b/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
@@ -13,7 +13,7 @@ streams = resolve_stream('type', 'EEG')
 
 # create a new inlet to read from the stream
 inlet = StreamInlet(streams[0])
-duration = 3
+duration = 10
 
 sleep(0)
 
@@ -25,7 +25,7 @@ def testLSLSamplingRate():
     while time.time() <= start + duration:
         # get chunks of samples
         chunk, timestamp = inlet.pull_chunk()
-        if chunk:
+        if timestamp:
             numChunks += 1
             for sample in chunk:
                 numSamples += 1
@@ -44,7 +44,7 @@ def testLSLPulseData():
 
     while time.time() <= start + duration:
         chunk, timestamp = inlet.pull_chunk()
-        if chunk:
+        if timestamp:
             for sample in chunk:
                 # print(sample)
                 raw_pulse_signal.append(sample[1])

--- a/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
+++ b/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
@@ -24,10 +24,10 @@ def testLSLSamplingRate():
 
     while time.time() <= start + duration:
         # get chunks of samples
-        samples, timestamp = inlet.pull_sample()
+        samples, timestamp = inlet.pull_chunk()
         if timestamp:
             numChunks += 1
-            # print( len(samples) )
+            print( len(samples) )
             numSamples += len(samples)
             # print(samples)
 
@@ -44,10 +44,11 @@ def testLSLPulseData():
     raw_pulse_signal = []
 
     while time.time() <= start + duration:
-        sample, timestamp = inlet.pull_sample()
-        if sample:
-            print(sample[1])
-            raw_pulse_signal.append(sample[1])
+        chunk, timestamp = inlet.pull_chunk()
+        if chunk:
+            for sample in chunk:
+                print(sample)
+                raw_pulse_signal.append(sample[1])
 
     print(raw_pulse_signal)
     plt.plot(raw_pulse_signal)

--- a/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
+++ b/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
@@ -1,0 +1,57 @@
+"""Example program to show how to read a multi-channel time series from LSL."""
+import time
+from pylsl import StreamInlet, resolve_stream
+from time import sleep
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import style
+from collections import deque
+
+# first resolve an EEG stream on the lab network
+print("looking for an EEG stream...")
+streams = resolve_stream('type', 'EEG')
+
+# create a new inlet to read from the stream
+inlet = StreamInlet(streams[0])
+duration = 3
+
+sleep(0)
+
+def testLSLSamplingRate():
+    start = time.time()
+    numSamples = 0
+    numChunks = 0
+
+    while time.time() <= start + duration:
+        # get chunks of samples
+        samples, timestamp = inlet.pull_sample()
+        if timestamp:
+            numChunks += 1
+            # print( len(samples) )
+            numSamples += len(samples)
+            # print(samples)
+
+    print( "Number of Chunks == {}".format(numChunks) )
+    print( "Avg Sampling Rate == {}".format(numSamples / duration) )
+
+
+testLSLSamplingRate()
+
+print("gathering data to plot...")
+
+def testLSLPulseData():
+    start = time.time()
+    raw_pulse_signal = []
+
+    while time.time() <= start + duration:
+        sample, timestamp = inlet.pull_sample()
+        if sample:
+            print(sample[1])
+            raw_pulse_signal.append(sample[1])
+
+    print(raw_pulse_signal)
+    plt.plot(raw_pulse_signal)
+    plt.ylabel('raw analog signal')
+    plt.show()
+
+testLSLPulseData()

--- a/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
+++ b/Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py
@@ -24,12 +24,11 @@ def testLSLSamplingRate():
 
     while time.time() <= start + duration:
         # get chunks of samples
-        samples, timestamp = inlet.pull_chunk()
-        if timestamp:
+        chunk, timestamp = inlet.pull_chunk()
+        if chunk:
             numChunks += 1
-            print( len(samples) )
-            numSamples += len(samples)
-            # print(samples)
+            for sample in chunk:
+                numSamples += 1
 
     print( "Number of Chunks == {}".format(numChunks) )
     print( "Avg Sampling Rate == {}".format(numSamples / duration) )
@@ -47,10 +46,11 @@ def testLSLPulseData():
         chunk, timestamp = inlet.pull_chunk()
         if chunk:
             for sample in chunk:
-                print(sample)
+                # print(sample)
                 raw_pulse_signal.append(sample[1])
 
     print(raw_pulse_signal)
+    print( "Avg Sampling Rate == {}".format(len(raw_pulse_signal) / duration) )
     plt.plot(raw_pulse_signal)
     plt.ylabel('raw analog signal')
     plt.show()

--- a/Networking-Test-Kit/UDP/udp_receive_pulse.py
+++ b/Networking-Test-Kit/UDP/udp_receive_pulse.py
@@ -6,11 +6,16 @@ import signal
 import struct
 import os
 import json
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import style
+
+raw_pulse_signal = []
 
 # Print received message to console
 def print_message(*args):
     try:
-        print(args[0]) #added to see raw data 
+        # print(args[0]) #added to see raw data 
         obj = json.loads(args[0].decode())
         print(obj.get('data'))
     except BaseException as e:
@@ -81,14 +86,21 @@ if __name__ == "__main__":
   print("Listening...")
   start = time.time()
   numSamples = 0
-  duration = 10
+  duration = 3
+  
   while time.time() <= start + duration:
     data, addr = sock.recvfrom(20000) # buffer size is 20000 bytes
     if args.option=="print":
       print_message(data)
+      sample = json.loads(data.decode()).get('data')[1]
+      raw_pulse_signal.append(sample)
       numSamples += 1
     elif args.option=="record":
       record_to_file(data)
+
 print( "Samples == {}".format(numSamples) )
 print( "Duration == {}".format(duration) )
 print( "Avg Sampling Rate == {}".format(numSamples / duration) )
+plt.plot(raw_pulse_signal)
+plt.ylabel('raw analog signal')
+plt.show()

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
         <key>CFBundleShortVersionString</key>
         <string>4</string>
         <key>CFBundleVersion</key>
-        <string>5.0.3-alpha.2</string>
+        <string>5.0.3-alpha.3</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -64,7 +64,7 @@ import http.requests.*;
 //                       Global Variables & Instances
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v5.0.3-alpha.2";
+String localGUIVersionString = "v5.0.3-alpha.3";
 String localGUIVersionDate = "January 2020";
 String guiLatestVersionGithubAPI = "https://api.github.com/repos/OpenBCI/OpenBCI_GUI/releases/latest";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -2015,13 +2015,14 @@ class Stream extends Thread {
                 }
             // LSL
             } else if (this.protocol.equals("LSL")) { ///////////////////This needs to be checked
-                for (int i = 0; i < (w_pulsesensor.PulseWaveY.length); i++) {
-                    dataToSend[0] = w_pulsesensor.BPM;  //Array output
-                    dataToSend[1] = w_pulsesensor.PulseWaveY[i];
-                    dataToSend[2] = w_pulsesensor.IBI;
-                }
+                float[] _dataToSend = new float[3];
+                //for (int i = 0; i < (w_pulsesensor.PulseWaveY.length); i++) {
+                    _dataToSend[0] = w_pulsesensor.BPM;  //Array output
+                    _dataToSend[1] = w_pulsesensor.PulseWaveY[w_pulsesensor.PulseWaveY.length-1];
+                    _dataToSend[2] = w_pulsesensor.IBI;
+                //}
                 // Add timestamp to LSL Stream
-                outlet_data.push_chunk(dataToSend);
+                outlet_data.push_sample(_dataToSend);
             // Serial
             } else if (this.protocol.equals("Serial")) {     // Send Pulse Data (BPM,Signal,IBI) over Serial
                 for (int i = 0; i < (w_pulsesensor.PulseWaveY.length); i++) {

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -1357,9 +1357,10 @@ class Stream extends Thread {
                 }
             } else {
                 if (checkForData()) {
-                    sendData();
-                    setDataFalse();
+                    //sendData();
+                    //setDataFalse();
                 }
+                sendData();
             }
         }
     }

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -1349,9 +1349,8 @@ class Stream extends Thread {
                         println(e.getMessage());
                     }
                 } else {
-                    sendData();
-                        if (checkForData()) {
-                            
+                        if (checkForData()) { //This needs to be removed in next version of the GUI
+                            sendData();
                             setDataFalse();
                         } else {
                             try {
@@ -1370,10 +1369,10 @@ class Stream extends Thread {
                     println(e.getMessage());
                 }
             } else {
-                if (checkForData()) {
+                //if (checkForData()) {
                     //sendData();
                     //setDataFalse();
-                }
+                //}
                 sendData();
             }
         }

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -2015,14 +2015,36 @@ class Stream extends Thread {
                 }
             // LSL
             } else if (this.protocol.equals("LSL")) { ///////////////////This needs to be checked
-                float[] _dataToSend = new float[3];
+                /*
+                float[] _dataToSend = new float[[3];
                 //for (int i = 0; i < (w_pulsesensor.PulseWaveY.length); i++) {
                     _dataToSend[0] = w_pulsesensor.BPM;  //Array output
                     _dataToSend[1] = w_pulsesensor.PulseWaveY[w_pulsesensor.PulseWaveY.length-1];
                     _dataToSend[2] = w_pulsesensor.IBI;
                 //}
+                float[] _dataToSend = new float[numChan * 125];
+                for (int i = 0; i < numChan; i++) {
+                    for (int j = 0; j < 125; j++) {
+                        _dataToSend[j+125*i] = fftBuff[i].getBand(j);
+                    }
+                }
                 // Add timestamp to LSL Stream
-                outlet_data.push_sample(_dataToSend);
+                // From LSLLink Library: The time stamps of other samples are automatically derived based on the sampling rate of the stream.
+                outlet_data.push_chunk(_dataToSend);
+                */
+                int numDataPoints = 3;
+                double[][] frameData = currentBoard.getFrameData();
+                int[] analogChannels = ((AnalogCapableBoard)currentBoard).getAnalogChannels();
+                float[] _dataToSend = new float[frameData[0].length * numDataPoints];
+                for (int i = 0; i < frameData[0].length; i++)
+                {
+                    int raw_signal = (int)(frameData[analogChannels[0]][i]);
+                    _dataToSend[numDataPoints*i] = w_pulsesensor.BPM;
+                    _dataToSend[numDataPoints*i+1] = raw_signal;
+                    _dataToSend[numDataPoints*i+2] = w_pulsesensor.IBI;
+                }
+                // Add timestamp to LSL Stream
+                outlet_data.push_chunk(_dataToSend);
             // Serial
             } else if (this.protocol.equals("Serial")) {     // Send Pulse Data (BPM,Signal,IBI) over Serial
                 for (int i = 0; i < (w_pulsesensor.PulseWaveY.length); i++) {

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -1358,6 +1358,7 @@ class Stream extends Thread {
             } else {
                 if (checkForData()) {
                     sendData();
+                    setDataFalse();
                 }
             }
         }

--- a/OpenBCI_GUI/W_PulseSensor.pde
+++ b/OpenBCI_GUI/W_PulseSensor.pde
@@ -100,8 +100,15 @@ class W_PulseSensor extends Widget {
 
         for (int i=0; i < PulseBuffSize; i++ ) {
             int signal = (int)(allData.get(i)[analogChannels[0]]);
-            processSignal(signal);
+            //processSignal(signal);
             PulseWaveY[i] = signal;
+        }
+
+        double[][] frameData = currentBoard.getFrameData();
+        for (int i = 0; i < frameData[0].length; i++)
+        {
+            int signal = (int)(frameData[analogChannels[0]][i]);
+            processSignal(signal);
         }
 
         //ignore top left button interaction when widgetSelector dropdown is active


### PR DESCRIPTION
Make it so that the Pulse Sensor Widget + Networking output for Pulse data type is both functional and usable in GUI v5.

Fixes #943 

Testing:
- [x] OSC using MaxMSP
- [x] UDP using `Networking-Test-Kit/UDP/udp_receive_pulse.py`
- [x] LSL using `Networking-Test-Kit/LSL/lslStreamTest_AnalogPinPulse.py`
~~- [ ] Serial (difficult to test without Virtual Com Port).~~

All tests passing for this data type. LSL seems to drop a few packets. UDP and OSC are close to flawless sampling rate. Tested on Mac. Serial output for Pulse data should work as expected.

Might help to have someone else test the Serial output for fun. Example: Map raw signal to LED brightness.

___

- [x] Update changelog and bump version to v5.0.3-alpha.3