### PR TITLE
GUI-wide settings class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # v5.0.7
 
 ### Improvements
-* Show warning in footer when a new version of the GUI is available #992
+* Show info in footer when a new version of the GUI is available #992
+* Add GUI-wide settings class to keep certain settings across sessions and app starts #997
 
 ### Bug Fixes
 * Fix GUI not running on some Macs due to high-dpi screen code #987 #990
+* Fix streaming multiple data types over LSL #971
 
 # v5.0.6
 

--- a/OpenBCI_GUI/ADS1299SettingsController.pde
+++ b/OpenBCI_GUI/ADS1299SettingsController.pde
@@ -138,7 +138,7 @@ class ADS1299SettingsController {
                 }
             }
 
-            boolean showCustomCommandUI = settings.expertModeToggle;
+            boolean showCustomCommandUI = guiSettings.getExpertModeBoolean();
             
             //Draw background behind command buttons
             pushStyle();

--- a/OpenBCI_GUI/CustomCp5Classes.pde
+++ b/OpenBCI_GUI/CustomCp5Classes.pde
@@ -90,7 +90,8 @@ class ButtonHelpText{
     }
 
     public void draw(){
-        if (!isVisible || settings.expertModeToggle) {
+        //When using expert mode, disable help text over UI objects
+        if (!isVisible || guiSettings.getExpertModeBoolean()) {
             return;
         }
 

--- a/OpenBCI_GUI/GuiSettings.pde
+++ b/OpenBCI_GUI/GuiSettings.pde
@@ -1,0 +1,116 @@
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.*;
+
+
+interface GuiSettingsEnum {
+    public String getName();
+}
+
+enum ExpertModeEnum implements GuiSettingsEnum {
+    ON("Active", true),
+    OFF("Inactive", false);
+
+    private String name;
+    private boolean val;
+
+    ExpertModeEnum(String _name, boolean _val) {
+        this.name = _name;
+        this.val = _val;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public boolean getBooleanValue() {
+        return val;
+    }
+}
+
+public class GuiSettingsValues {
+    public ExpertModeEnum expertMode;
+
+    public GuiSettingsValues() {
+    }
+}
+
+class GuiSettings {
+
+    public GuiSettingsValues values;
+    private String filename;
+
+    GuiSettings(String settingsDirectory) {
+
+        values = new GuiSettingsValues();
+        values.expertMode = ExpertModeEnum.OFF;
+        
+        StringBuilder settingsFilename = new StringBuilder(settingsDirectory);
+        settingsFilename.append("GuiWideSettings.txt");
+        filename = settingsFilename.toString();
+        File fileToCheck = new File(filename);
+        boolean fileExists = fileToCheck.exists();
+        if (fileExists) {
+            loadSettingsValues();
+            println("OpenBCI_GUI::Settings: Found and loaded existing GUI settings from.");
+        } else {
+            println("OpenBCI_GUI::Settings: Creating new GUI default settings file.");
+            saveToFile();
+        }
+    }
+
+    public boolean loadSettingsValues() {
+        try {
+            File file = new File(filename);
+            StringBuilder fileContents = new StringBuilder((int)file.length());        
+            Scanner scanner = new Scanner(file);
+            while(scanner.hasNextLine()) {
+                fileContents.append(scanner.nextLine() + System.lineSeparator());
+            }
+            Gson gson = new Gson();
+            values = gson.fromJson(fileContents.toString(), GuiSettingsValues.class);
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+            outputWarn("OpenBCI_GUI::Settings: Error loading GUI-wide settings from file. Attempting to create a new one.");
+            return false;
+        }
+    }
+
+    public String getJson() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(values);
+    }
+
+    public boolean saveToFile() {
+        String json = getJson();
+        try {
+            FileWriter writer = new FileWriter(filename);
+            writer.write(json);
+            writer.close();
+            println("OpenBCI_GUI::Settings: Successfully saved GUI-wide settings to file!");
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+            outputWarn("OpenBCI_GUI::Settings: Error saving GUI-wide settings to file. Please make an issue on GitHub.");
+            return false;
+        }
+    }
+
+    //Call this method at the end of GUI main Setup in OpenBCI_GUI.pde to make sure everything exists
+    public void applySettingsToFrontEnd() {
+        topNav.configSelector.toggleExpertModeFrontEnd(values.expertMode.getBooleanValue());
+    }
+
+    public void setExpertMode(ExpertModeEnum val) {
+        values.expertMode = val;
+        saveToFile();
+    }
+
+    
+    public boolean getExpertModeBoolean() {
+        return values.expertMode.getBooleanValue();
+    }
+
+}

--- a/OpenBCI_GUI/GuiSettings.pde
+++ b/OpenBCI_GUI/GuiSettings.pde
@@ -30,7 +30,7 @@ enum ExpertModeEnum implements GuiSettingsEnum {
 }
 
 public class GuiSettingsValues {
-    public ExpertModeEnum expertMode;
+    private ExpertModeEnum expertMode = ExpertModeEnum.OFF;
 
     public GuiSettingsValues() {
     }
@@ -44,7 +44,6 @@ class GuiSettings {
     GuiSettings(String settingsDirectory) {
 
         values = new GuiSettingsValues();
-        values.expertMode = ExpertModeEnum.OFF;
         
         StringBuilder settingsFilename = new StringBuilder(settingsDirectory);
         settingsFilename.append("GuiWideSettings.json");
@@ -53,7 +52,7 @@ class GuiSettings {
         boolean fileExists = fileToCheck.exists();
         if (fileExists) {
             loadSettingsValues();
-            println("OpenBCI_GUI::Settings: Found and loaded existing GUI-wide Settings from.");
+            println("OpenBCI_GUI::Settings: Found and loaded existing GUI-wide Settings from file.");
         } else {
             println("OpenBCI_GUI::Settings: Creating new GUI-wide Settings file.");
             saveToFile();
@@ -101,18 +100,17 @@ class GuiSettings {
     }
 
     //Call this method at the end of GUI main Setup in OpenBCI_GUI.pde to make sure everything exists
-    public void applySettingsToFrontEnd() {
-        topNav.configSelector.toggleExpertModeFrontEnd(values.expertMode.getBooleanValue());
+    //Has to be in this class to make sure other classes exist
+    public void applySettings() {
+        topNav.configSelector.toggleExpertModeFrontEnd(getExpertModeBoolean());
     }
 
     public void setExpertMode(ExpertModeEnum val) {
         values.expertMode = val;
         saveToFile();
     }
-
     
     public boolean getExpertModeBoolean() {
         return values.expertMode.getBooleanValue();
     }
-
 }

--- a/OpenBCI_GUI/GuiSettings.pde
+++ b/OpenBCI_GUI/GuiSettings.pde
@@ -47,15 +47,15 @@ class GuiSettings {
         values.expertMode = ExpertModeEnum.OFF;
         
         StringBuilder settingsFilename = new StringBuilder(settingsDirectory);
-        settingsFilename.append("GuiWideSettings.txt");
+        settingsFilename.append("GuiWideSettings.json");
         filename = settingsFilename.toString();
         File fileToCheck = new File(filename);
         boolean fileExists = fileToCheck.exists();
         if (fileExists) {
             loadSettingsValues();
-            println("OpenBCI_GUI::Settings: Found and loaded existing GUI settings from.");
+            println("OpenBCI_GUI::Settings: Found and loaded existing GUI-wide Settings from.");
         } else {
-            println("OpenBCI_GUI::Settings: Creating new GUI default settings file.");
+            println("OpenBCI_GUI::Settings: Creating new GUI-wide Settings file.");
             saveToFile();
         }
     }
@@ -74,6 +74,8 @@ class GuiSettings {
         } catch (IOException e) {
             e.printStackTrace();
             outputWarn("OpenBCI_GUI::Settings: Error loading GUI-wide settings from file. Attempting to create a new one.");
+            //If there is an error, attempt to overwrite the file or create a new one
+            saveToFile();
             return false;
         }
     }

--- a/OpenBCI_GUI/Interactivity.pde
+++ b/OpenBCI_GUI/Interactivity.pde
@@ -31,7 +31,7 @@ synchronized void keyPressed() {
     boolean anyActiveTextfields = isNetworkingTextActive() || textFieldIsActive;
 
     if(!controlPanel.isOpen && !anyActiveTextfields){ //don't parse the key if the control panel is open
-        if (settings.expertModeToggle || key == ' ') { //Check if Expert Mode is On or Spacebar has been pressed
+        if (guiSettings.getExpertModeBoolean() || key == ' ') { //Check if Expert Mode is On or Spacebar has been pressed
             if ((int(key) >=32) && (int(key) <= 126)) {  //32 through 126 represent all the usual printable ASCII characters
                 parseKey(key);
             }

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -450,7 +450,7 @@ void delayedSetup() {
     }
 
     //Apply GUI-wide settings to front end at the end of setup
-    guiSettings.applySettingsToFrontEnd();
+    guiSettings.applySettings();
 }
 
 //====================== END-OF-SETUP ==========================//

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -279,8 +279,9 @@ static CustomOutputStream outputStream;
 public final static String stopButton_pressToStop_txt = "Stop Data Stream";
 public final static String stopButton_pressToStart_txt = "Start Data Stream";
 
-SessionSettings settings;
 DirectoryManager directoryManager;
+SessionSettings settings;
+GuiSettings guiSettings;
 
 final int navBarHeight = 32;
 TopNav topNav;
@@ -393,6 +394,7 @@ void setup() {
     // Copy sample data to the Users' Documents folder +  create Recordings folder
     directoryManager.init();
     settings = new SessionSettings();
+    guiSettings = new GuiSettings(directoryManager.getSettingsPath());
     userPlaybackHistoryFile = directoryManager.getSettingsPath()+"UserPlaybackHistory.json";
 
     //open window
@@ -446,6 +448,9 @@ void delayedSetup() {
         setupComplete = true; // signal that the setup thread has finished
         println("OpenBCI_GUI::Setup: Setup is complete!");
     }
+
+    //Apply GUI-wide settings to front end at the end of setup
+    guiSettings.applySettingsToFrontEnd();
 }
 
 //====================== END-OF-SETUP ==========================//
@@ -647,8 +652,9 @@ void initSystem() {
         settings.init();
         settings.initCheckPointFive();
     } else if (eegDataSource == DATASOURCE_GALEA) {
-        //After TopNav has been instantiated, default to Expert mode for Galea
-        topNav.configSelector.toggleExpertMode(true);
+        //After TopNav has been instantiated, force Expert mode for Galea by default
+        topNav.configSelector.toggleExpertModeFrontEnd(true);
+        guiSettings.setExpertMode(ExpertModeEnum.ON);
     }
     
     //Make sure topNav buttons draw in the correct spot

--- a/OpenBCI_GUI/SessionSettings.pde
+++ b/OpenBCI_GUI/SessionSettings.pde
@@ -25,9 +25,6 @@
 //      -- read the comments
 //      -- once you find the right place to add your setting, you can copy the surrounding style
 //      -- uses JSON keys
-//      -- Example: Expert Mode is a global boolean, so we include it under kJSONKeySettings
-//      -- We use one variable to load from JSON: loadExpertModeToggle
-//      -- And another variable to use in the GUI and with saving to JSON: expertModeToggle
 //      -- Example2: GUI version and settings version
 //      -- Requires new JSON key 'version` and settingsVersion
 //
@@ -252,8 +249,6 @@ class SessionSettings {
     int loadFramerate;
     int loadDatasource;
     boolean dataSourceError = false;
-    //used globally to track and determine if expertMode is on or off
-    public boolean expertModeToggle = false;
 
     String saveDialogName; //Used when Save button is pressed
     String loadDialogName; //Used when Load button is pressed
@@ -366,7 +361,6 @@ class SessionSettings {
 
         //Make a second JSON object within our JSONArray to store Global settings for the GUI
         JSONObject saveGlobalSettings = new JSONObject();
-        saveGlobalSettings.setBoolean("Expert Mode", expertModeToggle);
         saveGlobalSettings.setInt("Current Layout", currentLayout);
         saveGlobalSettings.setInt("Notch", dataProcessing.bsRange.getIndex());
         saveGlobalSettings.setInt("Bandpass Filter", dataProcessing.bpRange.getIndex());
@@ -587,7 +581,6 @@ class SessionSettings {
         //Load more global settings after this line, if needed
         int loadNotchSetting = loadGlobalSettings.getInt("Notch");
         int loadBandpassSetting = loadGlobalSettings.getInt("Bandpass Filter");
-        Boolean loadExpertModeToggle = loadGlobalSettings.getBoolean("Expert Mode");
         Boolean loadDataSmoothingSetting = (currentBoard instanceof SmoothingCapableBoard) ? loadGlobalSettings.getBoolean("Data Smoothing") : null;
 
         //get the FFT settings
@@ -762,10 +755,6 @@ class SessionSettings {
             ((SmoothingCapableBoard)currentBoard).setSmoothingActive(loadDataSmoothingSetting);
             topNav.updateSmoothingButtonText();
         }
-
-        //Apply Expert Mode toggle
-        //This should not be loaded with other session settings - RW Jan 2021
-        //topNav.configSelector.toggleExpertMode(loadExpertModeToggle);
 
         //Load and apply all of the settings that are in dropdown menus. It's a bit much, so it has it's own function below.
         loadApplyWidgetDropdownText();

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -967,7 +967,7 @@ class ConfigSelector {
         loadSessionSettings.setDescription("Expert Mode enables advanced keyboard shortcuts and access to all GUI features.");
     }
 
-     private void createDefaultSettingsButton(String name, String text, int _x, int _y, int _w, int _h) {
+    private void createDefaultSettingsButton(String name, String text, int _x, int _y, int _w, int _h) {
         defaultSessionSettings = createButton(settings_cp5, name, text, _x, _y, _w, _h);
         defaultSessionSettings.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
@@ -978,7 +978,7 @@ class ConfigSelector {
         defaultSessionSettings.setDescription("Expert Mode enables advanced keyboard shortcuts and access to all GUI features.");
     }
 
-     private void createClearAllSettingsButton(String name, String text, int _x, int _y, int _w, int _h) {
+    private void createClearAllSettingsButton(String name, String text, int _x, int _y, int _w, int _h) {
         clearAllGUISettings = createButton(settings_cp5, name, text, _x, _y, _w, _h, p5, 12, BUTTON_CAUTIONRED, WHITE);
         clearAllGUISettings.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
@@ -992,7 +992,7 @@ class ConfigSelector {
         clearAllGUISettings.setDescription("This will clear all user settings and playback history. You will be asked to confirm.");
     }
 
-     private void createClearSettingsNoButton(String name, String text, int _x, int _y, int _w, int _h) {
+    private void createClearSettingsNoButton(String name, String text, int _x, int _y, int _w, int _h) {
         clearAllSettingsNo = createButton(settings_cp5, name, text, _x, _y, _w, _h);
         clearAllSettingsNo.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
@@ -1005,7 +1005,7 @@ class ConfigSelector {
         });
     }
 
-     private void createClearSettingsYesButton(String name, String text, int _x, int _y, int _w, int _h) {
+    private void createClearSettingsYesButton(String name, String text, int _x, int _y, int _w, int _h) {
         clearAllSettingsYes = createButton(settings_cp5, name, text, _x, _y, _w, _h);
         clearAllSettingsYes.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -933,11 +933,13 @@ class ConfigSelector {
         expertMode.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
                 toggleVisibility();
-                toggleExpertMode(!settings.expertModeToggle);
-                String outputMsg = settings.expertModeToggle ?
+                boolean isActive = !guiSettings.getExpertModeBoolean();
+                toggleExpertModeFrontEnd(isActive);
+                String outputMsg = isActive ?
                     "Expert Mode ON: All keyboard shortcuts and features are enabled!" : 
                     "Expert Mode OFF: Use spacebar to start/stop the data stream.";
                 output(outputMsg);
+                guiSettings.setExpertMode(isActive ? ExpertModeEnum.ON : ExpertModeEnum.OFF);
             }
         });
         expertMode.setDescription("Expert Mode enables advanced keyboard shortcuts and access to all GUI features.");
@@ -1022,17 +1024,13 @@ class ConfigSelector {
         clearAllSettingsYes.setDescription("Clicking 'Yes' will delete all user settings and stop the session if running.");
     }
 
-    public void toggleExpertMode(boolean b) {
+    public void toggleExpertModeFrontEnd(boolean b) {
         if (b) {
             expertMode.getCaptionLabel().setText("Turn Expert Mode Off");
             expertMode.setColorBackground(BUTTON_EXPERTPURPLE);
-            println("GUI Settings: Expert Mode On");
-            settings.expertModeToggle = true;
         } else {
             expertMode.getCaptionLabel().setText("Turn Expert Mode On");
             expertMode.setColorBackground(BUTTON_NOOBGREEN);
-            println("GUI Settings: Expert Mode Off");
-            settings.expertModeToggle = false;
         }
     } 
 }

--- a/OpenBCI_GUI/TopNav.pde
+++ b/OpenBCI_GUI/TopNav.pde
@@ -535,10 +535,6 @@ class TopNav {
         //This will also set the description/help-text for this cp5 button
         final Boolean upToDate = guiVersionIsUpToDate();
 
-        if (!upToDate) {
-            outputWarn("Update Available! Press the \"Update\" button at the top of the GUI to download the latest version.");
-        }
-
         updateGuiVersionButton.onRelease(new CallbackListener() {
             public void controlEvent(CallbackEvent theEvent) {
                 if (upToDate == null) {
@@ -553,6 +549,14 @@ class TopNav {
                 }
             }
         });
+
+        if (upToDate == null) {
+            return;
+        }
+
+        if (!upToDate) {
+            outputWarn("Update Available! Press the \"Update\" button at the top of the GUI to download the latest version.");
+        }
     }
 
     private void createTopNavSettingsButton(String text, int _x, int _y, int _w, int _h, PFont font, int _fontSize, color _bg, color _textColor) {


### PR DESCRIPTION
Add GUI-wide settings class to keep certain settings across sessions and app starts #997

Uses pattern established by ADS1299SettingsController.pde which uses GSON and a specific class for storing data values.