### PR TITLE
Remove30secwindowfocuswidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 * Show warning in footer when a new version of the GUI is available #992
+* Remove 30 second window option from Focus widget
 
 ### Bug Fixes
 * Fix GUI not running on some Macs due to high-dpi screen code #987 #990

--- a/OpenBCI_GUI/FocusEnums.pde
+++ b/OpenBCI_GUI/FocusEnums.pde
@@ -14,8 +14,7 @@ public enum FocusXLim implements FocusEnum
 {
     FIVE (0, 5, "5 sec"),
     TEN (1, 10, "10 sec"),
-    TWENTY (2, 20, "20 sec"),
-    THIRTY (3, 30, "30 sec");
+    TWENTY (2, 20, "20 sec");
 
     private int index;
     private int value;


### PR DESCRIPTION
30 second window option in the focus widget is not ideal and may not be useful for most user's purposes. Remove this. Can be added back later if necessary. Realized this when writing up the documentation for the new focus widget. Also, a 30 second Gplot is kind of slow.