### PR TITLE
update brainflow to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v5.1.1
+
+### Bug Fixes
+
+### Improvements
+* Update to BrainFlow 5.0.1
+
 # v5.1.0
 
 ### Bug Fixes

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -124,29 +124,26 @@ class DataProcessing {
             
             //Apply BandStop filter if the filter should be active on this channel
             if (filterSettings.values.bandStopFilterActive[Ichan].isActive()) {
-                double chebyshevRipple = filterSettings.values.bandStopFilterType[Ichan] == BrainFlowFilterType.CHEBYSHEV ? 1.0d : 0d;
                 DataFilter.perform_bandstop(
                     tempArray,
                     currentBoard.getSampleRate(),
-                    filterSettings.values.bandStopCenterFreq[Ichan],
-                    filterSettings.values.bandStopWidth[Ichan],
+                    filterSettings.values.bandStopStartFreq[Ichan],
+                    filterSettings.values.bandStopStopFreq[Ichan],
                     filterSettings.values.bandStopFilterOrder[Ichan].getValue(),
                     filterSettings.values.bandStopFilterType[Ichan].getValue(),
-                    chebyshevRipple);
+                    1.0);
             }
 
             //Apply BandPass filter if the filter should be active on this channel
             if (filterSettings.values.bandPassFilterActive[Ichan].isActive()) {
-                Pair<Double, Double> centerAndWidth = filterSettings.values.getBandPassCenterAndWidth(Ichan);
-                double chebyshevRipple = filterSettings.values.bandPassFilterType[Ichan] == BrainFlowFilterType.CHEBYSHEV ? 1.0d : 0d;
                 DataFilter.perform_bandpass(
                     tempArray,
                     currentBoard.getSampleRate(),
-                    centerAndWidth.getLeft(),
-                    centerAndWidth.getRight(),
+                    filterSettings.values.bandPassStartFreq[Ichan],
+                    filterSettings.values.bandPassStopFreq[Ichan],
                     filterSettings.values.bandPassFilterOrder[Ichan].getValue(),
                     filterSettings.values.bandPassFilterType[Ichan].getValue(),
-                    chebyshevRipple);
+                    1.0);
             }
 
             //Apply Environmental Noise filter on all channels. Do it like this since there are no codes for NONE or FIFTY_AND_SIXTY in BrainFlow

--- a/OpenBCI_GUI/FilterSettings.pde
+++ b/OpenBCI_GUI/FilterSettings.pde
@@ -8,14 +8,14 @@ public class FilterSettingsValues {
     public GlobalEnvironmentalFilter globalEnvFilter;
 
     public FilterActiveOnChannel masterBandStopFilterActive;
-    public double masterBandStopCenterFreq;
-    public double masterBandStopWidth;
+    public double masterBandStopStartFreq;
+    public double masterBandStopStopFreq;
     public BrainFlowFilterType masterBandStopFilterType = BrainFlowFilterType.BUTTERWORTH;
     public BrainFlowFilterOrder masterBandStopFilterOrder = BrainFlowFilterOrder.TWO;
 
     public FilterActiveOnChannel[] bandStopFilterActive;
-    public double[] bandStopCenterFreq;
-    public double[] bandStopWidth;
+    public double[] bandStopStartFreq;
+    public double[] bandStopStopFreq;
     public BrainFlowFilterType[] bandStopFilterType;
     public BrainFlowFilterOrder[] bandStopFilterOrder;
     
@@ -38,19 +38,19 @@ public class FilterSettingsValues {
 
         //Set Master Values for all channels for BandStop Filter
         masterBandStopFilterActive = FilterActiveOnChannel.OFF;
-        masterBandStopCenterFreq = 60;
-        masterBandStopWidth = 4;
+        masterBandStopStartFreq = 58;
+        masterBandStopStopFreq = 62;
         masterBandStopFilterType = BrainFlowFilterType.BUTTERWORTH;
         masterBandStopFilterOrder = BrainFlowFilterOrder.FOUR;
         //Create and assign master value to all channels
         bandStopFilterActive = new FilterActiveOnChannel[channelCount];
-        bandStopCenterFreq = new double[channelCount];
-        bandStopWidth = new double[channelCount];
+        bandStopStartFreq = new double[channelCount];
+        bandStopStopFreq = new double[channelCount];
         bandStopFilterType = new BrainFlowFilterType[channelCount];
         bandStopFilterOrder = new BrainFlowFilterOrder[channelCount];
         Arrays.fill(bandStopFilterActive, masterBandStopFilterActive);
-        Arrays.fill(bandStopCenterFreq, masterBandStopCenterFreq);
-        Arrays.fill(bandStopWidth, masterBandStopWidth);
+        Arrays.fill(bandStopStartFreq, masterBandStopStartFreq);
+        Arrays.fill(bandStopStopFreq, masterBandStopStopFreq);
         Arrays.fill(bandStopFilterType, masterBandStopFilterType);
         Arrays.fill(bandStopFilterOrder, masterBandStopFilterOrder);
 
@@ -72,13 +72,6 @@ public class FilterSettingsValues {
         Arrays.fill(bandPassStopFreq, masterBandPassStopFreq);
         Arrays.fill(bandPassFilterType, masterBandPassFilterType);
         Arrays.fill(bandPassFilterOrder, masterBandPassFilterOrder);
-    }
-
-    //Called in data processing to convert start & stop frequencies to center & width frequencies. Makes it simpler for users on the front-end.
-    public Pair<Double, Double> getBandPassCenterAndWidth(int chan) {
-        double centerFreq = (bandPassStartFreq[chan] + bandPassStopFreq[chan]) / 2.0;
-        double bandWidth = bandPassStopFreq[chan] - bandPassStartFreq[chan];
-        return new ImmutablePair<Double, Double>(centerFreq, bandWidth);
     }
 }
 

--- a/OpenBCI_GUI/FilterUI.pde
+++ b/OpenBCI_GUI/FilterUI.pde
@@ -249,8 +249,8 @@ class FilterUIPopup extends PApplet implements Runnable {
             firstColumnHeader = "Start (Hz)";
             secondColumnHeader = "Stop (Hz)";
         } else if (filterSettings.values.brainFlowFilter == BFFilter.BANDSTOP) {
-            firstColumnHeader = "Center (Hz)";
-            secondColumnHeader = "Width (Hz)";
+            firstColumnHeader = "Start (Hz)";
+            secondColumnHeader = "Stop (Hz)";
         }
         text(firstColumnHeader, columnObjX[1], headerHeight + sm_spacer, textfieldWidth, headerHeight);
         text(secondColumnHeader, columnObjX[2], headerHeight + sm_spacer, textfieldWidth, headerHeight);
@@ -432,8 +432,8 @@ class FilterUIPopup extends PApplet implements Runnable {
                 if (filterSettings.values.masterBandStopFilterActive == FilterActiveOnChannel.ON) {
                     updateColor = onColor;
                 }
-                firstColumnTFValue = df.format(filterSettings.values.masterBandStopCenterFreq);
-                secondColumnTFValue = df.format(filterSettings.values.masterBandStopWidth);
+                firstColumnTFValue = df.format(filterSettings.values.masterBandStopStartFreq);
+                secondColumnTFValue = df.format(filterSettings.values.masterBandStopStopFreq);
                 updateFilterType = filterSettings.values.masterBandStopFilterType;
                 updateFilterOrder = filterSettings.values.masterBandStopFilterOrder;
                 break;
@@ -466,8 +466,8 @@ class FilterUIPopup extends PApplet implements Runnable {
                         updateColor = offColor;
                     }
                     //Fetch filter values
-                    firstColumnTFValue = df.format(filterSettings.values.bandStopCenterFreq[chan]);
-                    secondColumnTFValue = df.format(filterSettings.values.bandStopWidth[chan]);
+                    firstColumnTFValue = df.format(filterSettings.values.bandStopStartFreq[chan]);
+                    secondColumnTFValue = df.format(filterSettings.values.bandStopStopFreq[chan]);
                     //Fetch filter type
                     updateFilterType = filterSettings.values.bandStopFilterType[chan];
                     //Fetch order
@@ -704,9 +704,9 @@ class FilterUIPopup extends PApplet implements Runnable {
         switch (filterSettings.values.brainFlowFilter) {
             case BANDSTOP:
                 if (isFirstColumn) {
-                    val = filterSettings.defaultValues.masterBandStopCenterFreq;
+                    val = filterSettings.defaultValues.masterBandStopStartFreq;
                 } else {
-                    val = filterSettings.defaultValues.masterBandStopWidth;
+                    val = filterSettings.defaultValues.masterBandStopStopFreq;
                 }
                 break;
             case BANDPASS:
@@ -726,11 +726,11 @@ class FilterUIPopup extends PApplet implements Runnable {
         switch (filterSettings.values.brainFlowFilter) {
             case BANDSTOP:
                 if (isFirstColumn) {
-                    filterSettings.values.masterBandStopCenterFreq = valAsDouble;
-                    Arrays.fill(filterSettings.values.bandStopCenterFreq, filterSettings.values.masterBandStopCenterFreq);
+                    filterSettings.values.masterBandStopStartFreq = valAsDouble;
+                    Arrays.fill(filterSettings.values.bandStopStartFreq, filterSettings.values.masterBandStopStartFreq);
                 } else {
-                    filterSettings.values.masterBandStopWidth = valAsDouble;
-                    Arrays.fill(filterSettings.values.bandStopWidth, filterSettings.values.masterBandStopWidth);
+                    filterSettings.values.masterBandStopStopFreq = valAsDouble;
+                    Arrays.fill(filterSettings.values.bandStopStopFreq, filterSettings.values.masterBandStopStopFreq);
                 }
                 break;
             case BANDPASS:
@@ -755,9 +755,9 @@ class FilterUIPopup extends PApplet implements Runnable {
         switch (filterSettings.values.brainFlowFilter) {
             case BANDSTOP:
                 if (isFirstColumn) {
-                    val = filterSettings.defaultValues.bandStopCenterFreq[chan];
+                    val = filterSettings.defaultValues.bandStopStartFreq[chan];
                 } else {
-                    val = filterSettings.defaultValues.bandStopWidth[chan];
+                    val = filterSettings.defaultValues.bandStopStopFreq[chan];
                 }
                 break;
             case BANDPASS:
@@ -777,9 +777,9 @@ class FilterUIPopup extends PApplet implements Runnable {
         switch (filterSettings.values.brainFlowFilter) {
             case BANDSTOP:
                 if (isFirstColumn) {
-                    filterSettings.values.bandStopCenterFreq[chan] = valAsDouble;
+                    filterSettings.values.bandStopStartFreq[chan] = valAsDouble;
                 } else {
-                    filterSettings.values.bandStopWidth[chan] = valAsDouble;
+                    filterSettings.values.bandStopStopFreq[chan] = valAsDouble;
                 }
                 break;
             case BANDPASS:

--- a/OpenBCI_GUI/FocusEnums.pde
+++ b/OpenBCI_GUI/FocusEnums.pde
@@ -47,8 +47,8 @@ public enum FocusXLim implements IndexingInterface
 
 public enum FocusMetric implements IndexingInterface
 {
-    CONCENTRATION (0, "Concentration", BrainFlowMetrics.CONCENTRATION, "Concentrating"),
-    RELAXATION (1, "Relaxation", BrainFlowMetrics.RELAXATION, "Relaxing");
+    CONCENTRATION (0, "Concentration", BrainFlowMetrics.MINDFULNESS, "Concentrating"),
+    RELAXATION (1, "Relaxation", BrainFlowMetrics.RESTFULNESS, "Relaxing");
 
     private int index;
     private String label;
@@ -92,10 +92,7 @@ public enum FocusMetric implements IndexingInterface
 
 public enum FocusClassifier implements IndexingInterface
 {
-    REGRESSION (0, "Regression", BrainFlowClassifiers.REGRESSION),
-    KNN (1, "KNN", BrainFlowClassifiers.KNN),
-    SVM (2, "SVM", BrainFlowClassifiers.SVM),
-    LDA (3, "LDA", BrainFlowClassifiers.LDA);
+    REGRESSION (0, "Regression", BrainFlowClassifiers.DEFAULT_CLASSIFIER);
 
     private int index;
     private int value;

--- a/OpenBCI_GUI/Info.plist.tmpl
+++ b/OpenBCI_GUI/Info.plist.tmpl
@@ -23,7 +23,7 @@
         <key>CFBundleShortVersionString</key>
         <string>5</string>
         <key>CFBundleVersion</key>
-        <string>5.1.0</string>
+        <string>5.1.1</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>NSHumanReadableCopyright</key>

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -60,8 +60,8 @@ import http.requests.*;
 //                       Global Variables & Instances
 //------------------------------------------------------------------------
 //Used to check GUI version in TopNav.pde and displayed on the splash screen on startup
-String localGUIVersionString = "v5.1.0";
-String localGUIVersionDate = "May 2022";
+String localGUIVersionString = "v5.1.1-alpha.0";
+String localGUIVersionDate = "July 2022";
 String guiLatestVersionGithubAPI = "https://api.github.com/repos/OpenBCI/OpenBCI_GUI/releases/latest";
 String guiLatestReleaseLocation = "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest";
 Boolean guiIsUpToDate;

--- a/OpenBCI_GUI/W_Focus.pde
+++ b/OpenBCI_GUI/W_Focus.pde
@@ -272,13 +272,13 @@ class W_Focus extends Widget {
 
             //Full Source Code for this method: https://github.com/brainflow-dev/brainflow/blob/c5f0ad86683e6eab556e30965befb7c93e389a3b/src/data_handler/data_handler.cpp#L1115
             Pair<double[], double[]> bands = DataFilter.get_avg_band_powers (dataArray, channelsInDataArray, currentBoard.getSampleRate(), true);
-            double[] featureVector = ArrayUtils.addAll (bands.getLeft (), bands.getRight ());
+            double[] featureVector = bands.getLeft ();
 
             //Left array is Averages, right array is Standard Deviations. Update values using Averages.
             updateBandPowerTableValues(bands.getLeft());
 
             //Keep this here
-            double prediction = mlModel.predict(featureVector);
+            double prediction = mlModel.predict(featureVector)[0];
             //println("Concentration: " + prediction);
 
             //Send band power and prediction data to AuditoryNeurofeedback class


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

* change bandstop from center and width to start and stop, first reason for it - it matches brainflow code, second - I think params in filters should be consistent between bandpass and bandstop
* removed classifiers from focus widget, I thought about removing dropdawn also but decided to keep it for now(we still can remove it)