### PR TITLE
Fix CytonDaisy + SD Card sampling rate

### DIFF
--- a/OpenBCI_GUI/DataSourceSDCard.pde
+++ b/OpenBCI_GUI/DataSourceSDCard.pde
@@ -51,7 +51,7 @@ class DataSourceSDCard implements DataSource, FileBoard, AccelerometerCapableBoa
             }
             else {
                 if (samplingRate == 0) {
-                    samplingRate = 125;
+                    samplingRate = 250;
                     exgChannels = new int[] {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16};
                     totalChannels = 21;
                 }


### PR DESCRIPTION
CytonDaisy over-the-air sampling rate is 125, but it happens to store to SD card at 250. Tested and confirmed twice.

Relates to #893 