### PR TITLE
Filter .tty serial ports in Networking for Mac users (Issue #1097)

### DIFF
--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -179,7 +179,7 @@ class W_Networking extends Widget {
     private LinkedList<String> getCuCommPorts() {
         final SerialPort[] allCommPorts = SerialPort.getCommPorts();        
         LinkedList<String> cuCommPorts = new LinkedList<String>();
-        for (String port : allCommPorts) {
+        for (SerialPort port : allCommPorts) {
             if (isMac() && port.getSystemPortName().startsWith("tty")) {
                         continue;
                     }

--- a/OpenBCI_GUI/W_Networking.pde
+++ b/OpenBCI_GUI/W_Networking.pde
@@ -154,7 +154,9 @@ class W_Networking extends Widget {
         protocolMode = "UDP"; //Set Default to UDP
         protocolIndex = 2; //Set Default to UDP 
         addDropdown("Protocol", "Protocol", Arrays.asList(settings.nwProtocolArray), protocolIndex);
-        comPorts = new ArrayList<String>(Arrays.asList(processing.serial.Serial.list()));
+        // comPorts = new ArrayList<String>(Arrays.asList(processing.serial.Serial.list()));
+        // calls the new method getCuCommPorts to store the list of only .cu serial ports for Mac users
+        comPorts = new ArrayList<String>(getCuCommPorts());
         verbosePrint("comPorts = " + comPorts);
         comPortToSave = 0;
 
@@ -171,6 +173,22 @@ class W_Networking extends Widget {
         cp5ElementsToCheck.add((controlP5.Controller)dataOutputsButton);
         cp5ElementsToCheck.add((controlP5.Controller)cp5_networking_dropdowns.get(ScrollableList.class, "dataType1"));
         cp5ElementsToCheck.add((controlP5.Controller)cp5_networking_baudRate.get(ScrollableList.class, "baud_rate"));
+    }
+
+    // Filter out .tty ports for Mac users, to only show .cu addresses
+    private LinkedList<String> getCuCommPorts() {
+        final SerialPort[] allCommPorts = SerialPort.getCommPorts();        
+        LinkedList<String> cuCommPorts = new LinkedList<String>();
+        for (String port : allCommPorts) {
+            if (isMac() && port.getSystemPortName().startsWith("tty")) {
+                        continue;
+                    }
+            String found = "";
+            if (isMac() || isLinux()) found += "/dev/";
+            found += port.getSystemPortName();
+            cuCommPorts.add(found);
+        }
+        return cuCommPorts;
     }
 
     //Used to update the Hashmap


### PR DESCRIPTION
Added a new method getCuCommPorts() to W_Networking.pde.

The method filters out .tty ports from the SerialPort library for Mac users and returns the results as a LinkedList

This method is called to store the result as an ArrayList in comPorts, which is then fed to the dropdown.

These changes are made to resolve Issue #1097 as recommended changes are made in a branch "networking_filter_serial_ports" based off the "development" branch.