### PR TITLE
Fix Cyton impedance check board configuration

### DIFF
--- a/OpenBCI_GUI/BoardCyton.pde
+++ b/OpenBCI_GUI/BoardCyton.pde
@@ -450,8 +450,8 @@ implements ImpedanceSettingsBoard, AccelerometerCapableBoard, AnalogCapableBoard
 
             currentADS1299Settings.values.gain[channel] = Gain.X1;
             currentADS1299Settings.values.inputType[channel] = InputType.NORMAL;
-            currentADS1299Settings.values.bias[channel] = Bias.INCLUDE;
-            currentADS1299Settings.values.srb2[channel] = Srb2.DISCONNECT;
+            currentADS1299Settings.values.bias[channel] = Bias.NO_INCLUDE;
+            currentADS1299Settings.values.srb2[channel] = Srb2.CONNECT;
             currentADS1299Settings.values.srb1[channel] = Srb1.DISCONNECT;
 
             fullCommand.append(currentADS1299Settings.getValuesString(channel, currentADS1299Settings.values));


### PR DESCRIPTION
Closes #1204 

The Cyton impedance check configuration appears to be incorrectly disconnecting SRB2 and using Bias instead. This has led to incorrect impedance measurements as shown in https://github.com/OpenBCI/OpenBCI_GUI/issues/1204. This fix results in correct measurements with a 51 kOhm resistor - more tests to follow.