### PR TITLE
Fix detection of plugdev group for Linux users

### DIFF
--- a/OpenBCI_GUI/Extras.pde
+++ b/OpenBCI_GUI/Extras.pde
@@ -159,6 +159,34 @@ public boolean isElevationNeeded(String path) {
     return result;
 }
 /**
+* Determines if user is in elevated group (plugdev).  
+*
+* @return <code>true</code> if user is in group plugdev, <code>false</code> otherwise.
+ */
+public boolean isInElevatedGroup() {
+    boolean result = true;
+    if (isLinux()) {
+        try {
+            String command = "groups";
+            Process p = Runtime.getRuntime().exec(command);
+            p.waitFor();
+            InputStream stdIn = p.getInputStream();
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stdIn));
+            String[] values = bufferedReader.readLine().split(" ");
+            for (int idx=0; idx<values.length; idx++) {
+                result = values[idx].equals("plugdev");
+                if (result) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    return result;
+}
+
+/**
 * Determine if user has administrative privileges.
 *
 * @return

--- a/OpenBCI_GUI/OpenBCI_GUI.pde
+++ b/OpenBCI_GUI/OpenBCI_GUI.pde
@@ -497,8 +497,8 @@ void delayedSetup() {
     //Apply GUI-wide settings to front end at the end of setup
     guiSettings.applySettings();
 
-    if (!isAdminUser() || isElevationNeeded()) {
-        outputError("OpenBCI_GUI: This application is not being run with Administrator access. This could limit the ability to connect to devices or read/write files.");
+    if (!isInElevatedGroup() && (!isAdminUser() || isElevationNeeded())) {
+        outputError("OpenBCI_GUI: This application is not being run with Administrator access or user is not member of plugdev group. This could limit the ability to connect to devices or read/write files.");
     }
 }
 


### PR DESCRIPTION
- Add method isInElevatedGroup
- check if the linux user is in plugdev
- add logic for admin error check

Our users are always for root password. This is no Option.
We only use Cyton Dongle and this Improvment aims for Dongle usage.

To use Dongle under linux users must be in plugdev group.