### PR TITLE
Fix GUI hanging if AuditoryFeedback sounds cannot be loaded

### DIFF
--- a/OpenBCI_GUI/AuditoryNeurofeedback.pde
+++ b/OpenBCI_GUI/AuditoryNeurofeedback.pde
@@ -57,6 +57,7 @@ class AuditoryNeurofeedback {
 
     //Use band powers or prediction value to control volume of each sound file
     public void update(double[] bandPowers, float predictionVal) {
+        if (!audioOutputIsAvailable) {return;}
         if (usingBandPowers) {
             for (int i = 0; i < NUM_SOUND_FILES; i++) {
                 float gain = map((float)bandPowers[i], 0.1, .7, MIN_GAIN + 20f, MAX_GAIN);
@@ -85,6 +86,7 @@ class AuditoryNeurofeedback {
     }
 
     public void killAudio() {
+        if (!audioOutputIsAvailable) {return;}
         for (int i = 0; i < NUM_SOUND_FILES; i++) {
             auditoryNfbFilePlayers[i].pause();
             auditoryNfbFilePlayers[i].rewind();


### PR DESCRIPTION
RW EDIT: Fixes #1236 

___

This commit adds conditional control over execution of `AuditoryNeurofeedback.update()` and `AuditoryNeurofeedback.killAudio()` in case a JavaSound Minim SourceDataLine could not be secured, causing the program to hang.