### PR TITLE
Update analog read value range

### DIFF
--- a/OpenBCI_GUI/W_AnalogRead.pde
+++ b/OpenBCI_GUI/W_AnalogRead.pde
@@ -431,7 +431,7 @@ class AnalogReadBar{
             return;
         }
         
-        plot.setYLim(-_vertScaleValue, _vertScaleValue);
+        plot.setYLim(-10, _vertScaleValue);
     }
 
     void screenResized(int _x, int _y, int _w, int _h) {


### PR DESCRIPTION
Closes #1072 

Included a range of expected values for analog read values from 0 to 1024. Negative values will return 0 and values above 1024 will return 1024.