### PR TITLE
Change BrainFlowStreamer recording to NONE by default

### DIFF
--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -1611,7 +1611,7 @@ class BrainFlowStreamerBox {
     private Button outputToNetwork;
     private Button outputToFile;
     private ScrollableList bfFileSaveOption;
-    private DataWriterBFEnum dataWriterBfEnum = DataWriterBFEnum.DEFAULT;
+    private DataWriterBFEnum dataWriterBfEnum = DataWriterBFEnum.NONE;
     private final int HEADER_H = 14;
     private final int OBJECT_H = 24;
     private final String DEFAULT_IP_ADDRESS = "225.1.1.1";


### PR DESCRIPTION
Currently, the `DEFAULT` setting for the BrainFlowStreamer writes a .csv containing all session data (in addition to the .txt recorded by the GUI).

This means that unless it is manually set to NONE each time, there are two plaintext copies recorded per session, totaling ~8.5 MB/min. (~4.3 MB txt, ~4.2 MB csv)

This PR simply changes the initial BrainFlowStreamer enum value to NONE, so that only one copy is stored by default, while still allowing users to record data via BrainFlow if they prefer.
