### PR TITLE
Fix udp send marker example

### DIFF
--- a/Networking-Test-Kit/UDP/udp_send_marker.py
+++ b/Networking-Test-Kit/UDP/udp_send_marker.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
       # generate random float
       marker = random.uniform(0, 4)
       # package as byte array
-      msg = struct.pack('!d', marker)
+      msg = struct.pack('!f', marker)
       # send through socket
       sock.sendto(msg, (UDP_IP, UDP_PORT))
       time.sleep(.25)


### PR DESCRIPTION
The GUI expects markers as 32-bit floats, not doubles.  Sending doubles caused incorrect values (e.g., 3.0 read as ~~2.75), updated example to send a float instead
#1270