### PR TITLE
fix: remove duplicate brainflow streamers

### DIFF
--- a/OpenBCI_GUI/BoardBrainflow.pde
+++ b/OpenBCI_GUI/BoardBrainflow.pde
@@ -106,6 +106,9 @@ abstract class BoardBrainFlow extends Board {
         }
         try {
             boardShim.stop_stream();
+            if (!brainflowStreamer.isEmpty()) {
+                boardShim.delete_streamer(brainflowStreamer);
+            }
             streaming = false;
             time_last_datapoint = -1.0;
         }


### PR DESCRIPTION
A stopped BrainFlow output streamer remains registered and duplicates output after restart.

This change removes the BrainFlow output streamer after streaming stops.

Closes #1254.
