### PR TITLE
Save synchronized filtered time-series data

### DIFF
--- a/GuiUnitTests/FilteredDataSequence_UnitTests.pde
+++ b/GuiUnitTests/FilteredDataSequence_UnitTests.pde
@@ -1,0 +1,41 @@
+import org.junit.Assert;
+import org.junit.Test;
+
+public static class FilteredDataSequence_UnitTests {
+
+    @Test
+    public void acceptsContiguousFramesOfDifferentSizes() {
+        FilteredDataSequence sequence = currentApplet.new FilteredDataSequence(0);
+
+        sequence.accept(0, 1);
+        sequence.accept(1, 7);
+        sequence.accept(8, 25);
+
+        Assert.assertEquals(33, sequence.getNextSampleIndex());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectsDuplicateFrame() {
+        FilteredDataSequence sequence = currentApplet.new FilteredDataSequence(0);
+        sequence.accept(0, 10);
+        sequence.accept(0, 10);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rejectsMissingFrame() {
+        FilteredDataSequence sequence = currentApplet.new FilteredDataSequence(0);
+        sequence.accept(0, 10);
+        sequence.accept(12, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNegativeFirstSampleIndex() {
+        currentApplet.new FilteredDataSequence(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNegativeSampleCount() {
+        FilteredDataSequence sequence = currentApplet.new FilteredDataSequence(0);
+        sequence.accept(0, -1);
+    }
+}

--- a/GuiUnitTests/GuiUnitTests.pde
+++ b/GuiUnitTests/GuiUnitTests.pde
@@ -16,7 +16,8 @@ final String failFileName = "UNITTEST_FAILURE";
         PacketLossTracker_UnitTests.class,
         PacketLossTrackerCytonSerialDaisy_UnitTests.class, 
         PacketLossTrackerGanglionBLE_UnitTests.class,  
-        TimeTrackingQueue_UnitTests.class, })
+        TimeTrackingQueue_UnitTests.class,
+        FilteredDataSequence_UnitTests.class, })
 public class AllTests {};
 
 void setup() {

--- a/GuiUnitTests/GuiUnitTests.pde
+++ b/GuiUnitTests/GuiUnitTests.pde
@@ -5,6 +5,8 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.RunWith;
 import org.hamcrest.SelfDescribing;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 static GuiUnitTests currentApplet;
 final String failFileName = "UNITTEST_FAILURE";

--- a/GuiUnitTests/run-unittests.py
+++ b/GuiUnitTests/run-unittests.py
@@ -41,7 +41,7 @@ def main ():
         dir_list = os.listdir(sketch_dir)
         print("Files and directories in '", sketch_dir, "' :")
         print(dir_list)
-        subprocess.run(["processing-java", "--force", "--sketch=" + sketch_dir, "--run"])
+        subprocess.run(["processing-java", "--force", "--sketch=" + sketch_dir, "--run"], check=True)
     except Exception as e:
         print(e)
         delete_files(sketch_dir)

--- a/GuiUnitTests/run-unittests.py
+++ b/GuiUnitTests/run-unittests.py
@@ -11,6 +11,7 @@ import traceback
 #           function which conflicts with the unit test sketch
 #           Once we get rid of globals we could copy all PDEs
 files_to_unittest = [
+    "FilteredDataSequence.pde",
     "PacketLossTracker.pde",
     "TimeTrackingQueue.pde"
 ]

--- a/OpenBCI_GUI/ControlPanel.pde
+++ b/OpenBCI_GUI/ControlPanel.pde
@@ -883,13 +883,14 @@ class SessionDataBox {
     private Button autoSessionName;
     private Button outputODF;
     private Button outputBDF;
+    private ScrollableList filteredDataDropdown;
     private ScrollableList maxDurationDropdown;
     private String odfMessage = "Output has been set to OpenBCI Data Format (CSV).";
     private String bdfMessage = "Output has been set to BioSemi Data Format (BDF+).";
 
     SessionDataBox (int _x, int _y, int _w, int _h, int _padding, int _dataSource, int output, String textfieldName) {
         datasource = _dataSource;
-        odfModeHeight = bdfModeHeight + 24 + _padding;
+        odfModeHeight = bdfModeHeight + (24 + _padding) * 2;
         x = _x;
         y = _y;
         w = _w;
@@ -910,6 +911,7 @@ class SessionDataBox {
         createODFButton("odfButton", "OpenBCI", dataLogger.getDataLoggerOutputFormat(), x + padding, y + padding*2 + 18 + 58, (w-padding*3)/2, 24);
         createBDFButton("bdfButton", "BDF+", dataLogger.getDataLoggerOutputFormat(), x + padding*2 + (w-padding*3)/2, y + padding*2 + 18 + 58, (w-padding*3)/2, 24);
 
+        createFilteredDataDropdown("filteredDataSaveMode");
         List<String> fileDurationList = EnumHelper.getEnumStrings(OdfFileDuration.class);
         createMaxDurationDropdown("maxFileDuration", fileDurationList, odfFileDuration);
     }
@@ -925,6 +927,7 @@ class SessionDataBox {
 
         boolean odfIsSelected = dataLogger.getDataLoggerOutputFormat() == dataLogger.OUTPUT_SOURCE_ODF;
         h = odfIsSelected ? odfModeHeight : bdfModeHeight;
+        filteredDataDropdown.setVisible(odfIsSelected);
         maxDurationDropdown.setVisible(odfIsSelected);
         if (odfIsSelected && outputBDF.isOn()) {
             outputODF.setOn();
@@ -950,22 +953,77 @@ class SessionDataBox {
         popStyle();
 
         boolean odfIsSelected = dataLogger.getDataLoggerOutputFormat() == dataLogger.OUTPUT_SOURCE_ODF;
+        filteredDataDropdown.setVisible(odfIsSelected);
         maxDurationDropdown.setVisible(odfIsSelected);
         if (odfIsSelected) {
             pushStyle();
             //draw backgrounds to dropdown scrollableLists ... unfortunately ControlP5 doesn't have this by default, so we have to hack it to make it look nice...
             //Dropdown is drawn at the end of ControlPanel.draw()
             fill(OPENBCI_DARKBLUE);
-            maxDurationDropdown.setPosition(x + maxDurTextWidth, int(outputODF.getPosition()[1]) + 24 + padding);
-            //Carefully draw some text to the left of above dropdown, otherwise this text moves when changing WiFi mode
-            int extraPadding = 20;
+            int filteredDataY = int(outputODF.getPosition()[1]) + 24 + padding;
+            int maxDurationY = filteredDataY + 24 + padding;
+            filteredDataDropdown.setPosition(x + maxDurTextWidth, filteredDataY);
+            maxDurationDropdown.setPosition(x + maxDurTextWidth, maxDurationY);
             fill(OPENBCI_DARKBLUE);
             textFont(p4, 14);
-            text("Max File Duration", maxDurText_x, y + h - 24 - padding + extraPadding);
+            text("Recording Data", maxDurText_x, filteredDataY + 4);
+            text("Max File Duration", maxDurText_x, maxDurationY + 4);
             popStyle();
         }
 
         sessionData_cp5.draw();
+    }
+
+    private void createFilteredDataDropdown(String name) {
+        List<String> modes = Arrays.asList("Raw only", "Raw + Filtered");
+        boolean saveFiltered = guiSettings.getSaveFilteredTimeSeries();
+        String selectedMode = saveFiltered ? modes.get(1) : modes.get(0);
+
+        filteredDataDropdown = sessionData_cp5.addScrollableList(name)
+            .setOpen(false)
+            .setColor(dropdownColorsGlobal)
+            .setOutlineColor(150)
+            .setColorValueLabel(OPENBCI_DARKBLUE)
+            .setPosition(x + maxDurTextWidth, int(outputODF.getPosition()[1]) + 24 + padding)
+            .setSize((w-padding*3)/2, (modes.size() + 1) * 24)
+            .setBarHeight(24)
+            .setItemHeight(24)
+            .addItems(modes)
+            .setValue(saveFiltered ? 1 : 0)
+            .setVisible(false);
+
+        filteredDataDropdown.getCaptionLabel()
+            .toUpperCase(false)
+            .setText(selectedMode)
+            .setFont(p4)
+            .setSize(14)
+            .getStyle()
+            .setPaddingTop(4);
+        filteredDataDropdown.getValueLabel()
+            .toUpperCase(false)
+            .setText(selectedMode)
+            .setFont(h5)
+            .setSize(12)
+            .getStyle()
+            .setPaddingTop(3);
+
+        filteredDataDropdown.setDescription("Save a synchronized companion file containing the exact filtered EXG data shown by the GUI. Raw recording remains unchanged.");
+        filteredDataDropdown.addCallback(new CallbackListener() {
+            public void controlEvent(CallbackEvent theEvent) {
+                if (theEvent.getAction() == ControlP5.ACTION_BROADCAST) {
+                    int selectedIndex = (int)(theEvent.getController()).getValue();
+                    boolean shouldSaveFiltered = selectedIndex == 1;
+                    guiSettings.setSaveFilteredTimeSeries(shouldSaveFiltered);
+                    String mode = shouldSaveFiltered ? "Raw + Filtered" : "Raw only";
+                    filteredDataDropdown.getCaptionLabel().setText(mode);
+                    output("SessionData: Recording mode set to " + mode + ".");
+                } else if (theEvent.getAction() == ControlP5.ACTION_ENTER) {
+                    lockOutsideElements(true);
+                } else if (theEvent.getAction() == ControlP5.ACTION_LEAVE) {
+                    lockOutsideElements(filteredDataDropdown.isOpen());
+                }
+            }
+        });
     }
 
     private void createSessionNameTextfield(String name) {
@@ -1021,7 +1079,7 @@ class SessionDataBox {
             //.setColorForeground(color(125))    // border color when not selected
             //.setColorActive(BUTTON_PRESSED)       // border color when selected
             // .setColorCursor(color(26,26,26))
-            .setPosition(x + maxDurTextWidth, int(outputODF.getPosition()[1]) + 24 + padding)
+            .setPosition(x + maxDurTextWidth, int(outputODF.getPosition()[1]) + (24 + padding) * 2)
             .setSize((w-padding*3)/2, (_items.size() + 1) * 24)// + maxFreqList.size())
             .setBarHeight(24) //height of top/primary bar
             .setItemHeight(24) //height of all item/dropdown bars
@@ -1148,6 +1206,8 @@ class SessionDataBox {
         autoSessionName.setLock(lock);
         outputODF.setLock(lock);
         outputBDF.setLock(lock);
+        filteredDataDropdown.setLock(lock);
+        maxDurationDropdown.setLock(lock);
     }
 };
 
@@ -2521,5 +2581,4 @@ class InitBox {
         initSystemButton.getCaptionLabel().setText(text);
     }
 };
-
 

--- a/OpenBCI_GUI/DataLogger.pde
+++ b/OpenBCI_GUI/DataLogger.pde
@@ -1,6 +1,7 @@
 class DataLogger {
     //variables for writing EEG data out to a file
     private DataWriterODF fileWriterODF;
+    private DataWriterFilteredODF fileWriterFilteredODF;
     private DataWriterBDF fileWriterBDF;
     public DataWriterBF fileWriterBF; //Add the ability to simulataneously save to BrainFlow CSV, independent of BDF or ODF
     private String sessionName = "N/A";
@@ -12,6 +13,12 @@ class DataLogger {
     private boolean logFileIsOpen = false;
     private long logFileStartTime;
     private long logFileMaxDurationNano = -1;
+    private String currentRecordingName = "";
+    private String activeFilterSettingsJson = "";
+    private boolean activeSmoothingSetting = false;
+    private int filteredEpochNumber = 0;
+    private long nextFilteredSampleIndex = 0;
+    private boolean filteredRecordingFailed = false;
 
     DataLogger() {
         //Default to OpenBCI CSV Data Format
@@ -20,7 +27,10 @@ class DataLogger {
     }
 
     public void initialize() {
-
+        activeFilterSettingsJson = "";
+        filteredEpochNumber = 0;
+        nextFilteredSampleIndex = 0;
+        filteredRecordingFailed = false;
     }
 
     public void uninitialize() {
@@ -55,6 +65,114 @@ class DataLogger {
                 // Do nothing...
                 break;
         }
+    }
+
+    /**
+     * Save the exact filtered tail produced for the current raw board frame.
+     * This is called from processNewData() only after GUI filtering completes.
+     */
+    public void saveFilteredData(float[][] filteredDisplayData) {
+        if (!isLogFileOpen()
+                || outputDataSource != OUTPUT_SOURCE_ODF
+                || guiSettings == null
+                || !guiSettings.getSaveFilteredTimeSeries()
+                || filteredRecordingFailed) {
+            return;
+        }
+
+        double[][] rawFrameData = currentBoard.getFrameData();
+        int[] exgChannels = currentBoard.getEXGChannels();
+        if (exgChannels.length == 0
+                || rawFrameData.length == 0
+                || rawFrameData[exgChannels[0]].length == 0) {
+            return;
+        }
+
+        try {
+            String currentFilterSettingsJson = filterSettings.getJson();
+            boolean currentSmoothingSetting = getCurrentSmoothingSetting();
+            if (fileWriterFilteredODF == null
+                    || !currentFilterSettingsJson.equals(activeFilterSettingsJson)
+                    || currentSmoothingSetting != activeSmoothingSetting) {
+                FilteredDataMetadata metadata = getFilteredDataMetadata(
+                    currentFilterSettingsJson,
+                    currentSmoothingSetting
+                );
+                openNewFilteredLogFile(
+                    metadata,
+                    currentFilterSettingsJson,
+                    currentSmoothingSetting
+                );
+            }
+
+            int samplesWritten = fileWriterFilteredODF.append(
+                filteredDisplayData,
+                rawFrameData,
+                nextFilteredSampleIndex
+            );
+            nextFilteredSampleIndex += samplesWritten;
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            outputError("Filtered data recording stopped because sample alignment could not be guaranteed. Raw recording will continue.");
+            closeFilteredLogFile();
+            filteredRecordingFailed = true;
+        }
+    }
+
+    private boolean getCurrentSmoothingSetting() {
+        if (currentBoard instanceof SmoothingCapableBoard) {
+            return ((SmoothingCapableBoard)currentBoard).getSmoothingActive();
+        }
+        return false;
+    }
+
+    private FilteredDataMetadata getFilteredDataMetadata(
+        String currentFilterSettingsJson,
+        boolean smoothingActive
+    ) {
+        String brainFlowVersion = "Unknown";
+        try {
+            brainFlowVersion = BoardShim.get_version();
+        } catch (BrainFlowError e) {
+            println("DataLogging: Unable to read BrainFlow version for filtered metadata.");
+        }
+
+        return new FilteredDataMetadata(
+            currentBoard.getSampleRate(),
+            currentBoard.getClass().getName(),
+            localGUIVersionString,
+            brainFlowVersion,
+            smoothingActive,
+            currentFilterSettingsJson
+        );
+    }
+
+    private void openNewFilteredLogFile(
+        FilteredDataMetadata metadata,
+        String currentFilterSettingsJson,
+        boolean smoothingActive
+    ) {
+        closeFilteredLogFile();
+        filteredEpochNumber++;
+        fileWriterFilteredODF = new DataWriterFilteredODF(
+            getSessionPath(),
+            fileWriterODF.getFileName(),
+            currentRecordingName,
+            filteredEpochNumber,
+            nextFilteredSampleIndex,
+            metadata
+        );
+        activeFilterSettingsJson = currentFilterSettingsJson;
+        activeSmoothingSetting = smoothingActive;
+        println("OpenBCI_GUI: opened filtered ODF output file: " + fileWriterFilteredODF.getFileName());
+    }
+
+    private void closeFilteredLogFile() {
+        if (fileWriterFilteredODF != null) {
+            fileWriterFilteredODF.closeFile();
+        }
+        fileWriterFilteredODF = null;
+        activeFilterSettingsJson = "";
     }
 
     public void limitRecordingFileDuration() {
@@ -102,6 +220,10 @@ class DataLogger {
     }
 
     private void openNewLogFile(String _fileName) {
+        currentRecordingName = _fileName;
+        filteredEpochNumber = 0;
+        activeFilterSettingsJson = "";
+        filteredRecordingFailed = false;
         //close the file if it's open
         switch (outputDataSource) {
             case OUTPUT_SOURCE_ODF:
@@ -174,6 +296,7 @@ class DataLogger {
     }
 
     private void closeLogFileODF() {
+        closeFilteredLogFile();
         if (fileWriterODF != null) {
             fileWriterODF.closeFile();
         }

--- a/OpenBCI_GUI/DataProcessing.pde
+++ b/OpenBCI_GUI/DataProcessing.pde
@@ -39,6 +39,10 @@ void processNewData() {
     //apply additional processing for the time-domain montage plot (ie, filtering)
     dataProcessing.process(dataProcessingFilteredBuffer, fftBuff);
 
+    //The raw frame has already been logged. Save only the newly filtered tail
+    //that corresponds to that same frame.
+    dataLogger.saveFilteredData(dataProcessingFilteredBuffer);
+
     //look to see if the latest data is railed so that we can notify the user on the GUI
     for (int channel=0; channel < globalChannelCount; channel++) is_railed[channel].update(dataProcessingRawBuffer[channel], channel);
 

--- a/OpenBCI_GUI/DataWriterFilteredODF.pde
+++ b/OpenBCI_GUI/DataWriterFilteredODF.pde
@@ -1,0 +1,181 @@
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Immutable description of the processing pipeline used for one filtered
+ * recording epoch.  A new epoch is opened whenever this description changes.
+ */
+class FilteredDataMetadata {
+    public final int sampleRate;
+    public final String boardClass;
+    public final String guiVersion;
+    public final String brainFlowVersion;
+    public final boolean smoothingActive;
+    public final String filterConfigurationJson;
+    public final String configurationSha256;
+
+    FilteredDataMetadata(
+        int _sampleRate,
+        String _boardClass,
+        String _guiVersion,
+        String _brainFlowVersion,
+        boolean _smoothingActive,
+        String _filterConfigurationJson
+    ) {
+        sampleRate = _sampleRate;
+        boardClass = _boardClass;
+        guiVersion = _guiVersion;
+        brainFlowVersion = _brainFlowVersion;
+        smoothingActive = _smoothingActive;
+
+        Gson gson = new Gson();
+        filterConfigurationJson = gson.toJson(
+            new JsonParser().parse(_filterConfigurationJson)
+        );
+
+        StringBuilder fingerprint = new StringBuilder();
+        fingerprint.append("sampleRate=").append(sampleRate).append('\n');
+        fingerprint.append("boardClass=").append(boardClass).append('\n');
+        fingerprint.append("guiVersion=").append(guiVersion).append('\n');
+        fingerprint.append("brainFlowVersion=").append(brainFlowVersion).append('\n');
+        fingerprint.append("smoothingActive=").append(smoothingActive).append('\n');
+        fingerprint.append("pipeline=bandstop,bandpass,environmental-notch").append('\n');
+        fingerprint.append("precision=float32").append('\n');
+        fingerprint.append(filterConfigurationJson);
+        configurationSha256 = sha256(fingerprint.toString());
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encoded = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : encoded) {
+                hex.append(String.format("%02x", b & 0xff));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available.", e);
+        }
+    }
+}
+
+/**
+ * Writes only filtered EXG values to a companion OpenBCI text file.  The raw
+ * writer and raw file format remain unchanged for playback compatibility.
+ */
+class DataWriterFilteredODF {
+    private PrintWriter output;
+    private String fileName;
+    private long rowsWritten;
+    private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private FilteredDataSequence sequence;
+
+    DataWriterFilteredODF(
+        String sessionPath,
+        String rawFileName,
+        String recordingName,
+        int epochNumber,
+        long firstSampleIndex,
+        FilteredDataMetadata metadata
+    ) {
+        String epochSuffix = String.format("-epoch-%03d", epochNumber);
+        fileName = sessionPath + "OpenBCI-FILTERED-" + recordingName + epochSuffix + ".txt";
+        output = createWriter(fileName);
+        sequence = new FilteredDataSequence(firstSampleIndex);
+        rowsWritten = 0;
+        writeHeader(rawFileName, firstSampleIndex, metadata);
+    }
+
+    private void writeHeader(
+        String rawFileName,
+        long firstSampleIndex,
+        FilteredDataMetadata metadata
+    ) {
+        output.println("%OpenBCI Filtered EXG Data");
+        output.println("%Schema = openbci-filtered-timeseries/1");
+        output.println("%Source Raw File = " + new File(rawFileName).getName());
+        output.println("%First Sample Index = " + firstSampleIndex);
+        output.println("%Number of channels = " + currentBoard.getNumEXGChannels());
+        output.println("%Sample Rate = " + metadata.sampleRate + " Hz");
+        output.println("%Board = " + metadata.boardClass);
+        output.println("%OpenBCI GUI Version = " + metadata.guiVersion);
+        output.println("%BrainFlow Version = " + metadata.brainFlowVersion);
+        output.println("%Board Smoothing Active = " + metadata.smoothingActive);
+        output.println("%Display Pipeline Precision = float32");
+        output.println("%Filter Pipeline = BandStop -> BandPass -> Environmental Notch");
+        output.println("%Filter Configuration SHA-256 = " + metadata.configurationSha256);
+        output.println("%Filter Configuration JSON = " + metadata.filterConfigurationJson);
+
+        output.print("Sample Index, ");
+        int[] exgChannels = currentBoard.getEXGChannels();
+        String[] channelNames = ((Board)currentBoard).getChannelNames();
+        for (int i = 0; i < exgChannels.length; i++) {
+            output.print("Filtered " + channelNames[exgChannels[i]] + ", ");
+        }
+        output.println("Timestamp, Marker, Timestamp (Formatted)");
+    }
+
+    /**
+     * Append the filtered tail that corresponds exactly to rawFrameData.
+     * Returns the number of samples written.
+     */
+    public int append(
+        float[][] filteredDisplayData,
+        double[][] rawFrameData,
+        long firstSampleIndex
+    ) {
+        int[] exgChannels = currentBoard.getEXGChannels();
+        if (exgChannels.length == 0 || rawFrameData.length == 0) {
+            return 0;
+        }
+
+        int sampleCount = rawFrameData[exgChannels[0]].length;
+        if (sampleCount == 0) {
+            return 0;
+        }
+        if (filteredDisplayData.length != exgChannels.length) {
+            throw new IllegalArgumentException("Filtered EXG channel count does not match the board.");
+        }
+
+        int filteredStart = filteredDisplayData[0].length - sampleCount;
+        if (filteredStart < 0) {
+            throw new IllegalArgumentException("Filtered display buffer is shorter than the raw frame.");
+        }
+
+        sequence.accept(firstSampleIndex, sampleCount);
+        int timestampChannel = currentBoard.getTimestampChannel();
+        int markerChannel = currentBoard.getMarkerChannel();
+
+        for (int iSample = 0; iSample < sampleCount; iSample++) {
+            StringBuilder row = new StringBuilder();
+            row.append(firstSampleIndex + iSample).append(", ");
+            for (int iChannel = 0; iChannel < exgChannels.length; iChannel++) {
+                row.append(filteredDisplayData[iChannel][filteredStart + iSample]).append(", ");
+            }
+
+            double timestamp = rawFrameData[timestampChannel][iSample];
+            double marker = rawFrameData[markerChannel][iSample];
+            row.append(timestamp).append(", ");
+            row.append(marker).append(", ");
+            row.append(dateFormat.format(new Date((long)(timestamp * 1000.0))));
+            output.println(row.toString());
+            rowsWritten++;
+        }
+        return sampleCount;
+    }
+
+    public void closeFile() {
+        output.flush();
+        output.close();
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public long getRowsWritten() {
+        return rowsWritten;
+    }
+}

--- a/OpenBCI_GUI/FilteredDataSequence.pde
+++ b/OpenBCI_GUI/FilteredDataSequence.pde
@@ -1,0 +1,35 @@
+/**
+ * Tracks the sample range written to a filtered recording.
+ *
+ * The filtered writer receives data after the GUI processing pass, while the
+ * raw writer receives the same board frame before processing.  This guard
+ * makes gaps and duplicate frames explicit instead of silently producing a
+ * filtered file that no longer lines up with the raw recording.
+ */
+class FilteredDataSequence {
+    private long nextSampleIndex;
+
+    FilteredDataSequence(long firstSampleIndex) {
+        if (firstSampleIndex < 0) {
+            throw new IllegalArgumentException("First sample index must be non-negative.");
+        }
+        nextSampleIndex = firstSampleIndex;
+    }
+
+    public void accept(long firstSampleIndex, int sampleCount) {
+        if (sampleCount < 0) {
+            throw new IllegalArgumentException("Sample count must be non-negative.");
+        }
+        if (firstSampleIndex != nextSampleIndex) {
+            throw new IllegalStateException(
+                "Expected filtered sample " + nextSampleIndex +
+                " but received " + firstSampleIndex + "."
+            );
+        }
+        nextSampleIndex += sampleCount;
+    }
+
+    public long getNextSampleIndex() {
+        return nextSampleIndex;
+    }
+}

--- a/OpenBCI_GUI/GuiSettings.pde
+++ b/OpenBCI_GUI/GuiSettings.pde
@@ -1,5 +1,7 @@
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 import java.io.*;
 import java.util.regex.*;
@@ -40,6 +42,7 @@ public class GuiSettingsValues {
     public boolean autoStartDataStream = false;
     public boolean autoStartNetworkStream = false;
     public boolean autoLoadSessionSettings = false;
+    public boolean saveFilteredTimeSeries = false;
 
     public GuiSettingsValues() {
     }
@@ -77,25 +80,46 @@ class GuiSettings {
                 fileContents.append(scanner.nextLine() + System.lineSeparator());
             }
 
-            //Check for incompatible or old settings
-            if (validateJsonKeys(fileContents.toString())) {
-                Gson gson = new Gson();
-                values = gson.fromJson(fileContents.toString(), GuiSettingsValues.class);
+            boolean settingsHaveAllCurrentKeys = validateJsonKeys(fileContents.toString());
+            values = loadWithDefaults(fileContents.toString());
+
+            if (settingsHaveAllCurrentKeys) {
                 println("OpenBCI_GUI::Settings: Found and loaded existing GUI-wide Settings from file.");
             } else {
-                println("OpenBCI_GUI::Settings: Incompatible GUI-wide Settings found. Creating new file and resetting defaults.");
+                println("OpenBCI_GUI::Settings: Migrating GUI-wide Settings and preserving existing values.");
                 saveToFile();
             }
             
             return true;
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             outputWarn("OpenBCI_GUI::Settings: Error loading GUI-wide settings from file. Attempting to create a new one.");
             //If there is an error, attempt to overwrite the file or create a new one
             saveToFile();
             return false;
         }      
+    }
+
+    /**
+     * Merge known values from an older settings file onto current defaults.
+     * Missing new keys therefore receive safe defaults without resetting the
+     * preferences the user already selected.
+     */
+    private GuiSettingsValues loadWithDefaults(String savedJson) {
+        Gson gson = new Gson();
+        JsonParser parser = new JsonParser();
+        JsonObject merged = parser.parse(getJson()).getAsJsonObject();
+        JsonObject saved = parser.parse(savedJson).getAsJsonObject();
+
+        for (Map.Entry<String, com.google.gson.JsonElement> entry : saved.entrySet()) {
+            if (merged.has(entry.getKey())) {
+                merged.add(entry.getKey(), entry.getValue());
+            } else {
+                println("OpenBCI_GUI::Settings: Ignoring unknown GUI-wide setting: " + entry.getKey());
+            }
+        }
+        return gson.fromJson(merged, GuiSettingsValues.class);
     }
 
     public String getJson() {
@@ -239,6 +263,15 @@ class GuiSettings {
 
     public void setAutoLoadSessionSettings(boolean b) {
         values.autoLoadSessionSettings = b;
+        saveToFile();
+    }
+
+    public boolean getSaveFilteredTimeSeries() {
+        return values.saveFilteredTimeSeries;
+    }
+
+    public void setSaveFilteredTimeSeries(boolean b) {
+        values.saveFilteredTimeSeries = b;
         saveToFile();
     }
 }


### PR DESCRIPTION
## What changed

- adds an opt-in Raw + Filtered recording mode for OpenBCI text output;
- keeps the existing RAW ODF writer and playback format unchanged;
- writes the exact filtered display-buffer tail that corresponds to each new raw frame;
- records a monotonic sample index, board timestamp, marker, software versions, smoothing state, full per-channel filter JSON, and SHA-256 configuration fingerprint;
- opens a new filtered epoch file when filter or smoothing settings change;
- detects filtered sample gaps or duplicate frames and keeps RAW recording active if filtered recording fails;
- migrates GUI-wide settings without resetting existing preferences;
- adds unit coverage for sequence continuity, gaps, duplicates, and invalid ranges;
- makes Processing compilation failures fail the Python unit-test runner instead of being reported as success.

## Why

The GUI currently displays filtered time-series data but records only raw data. Users who need the exact displayed signal must stream it to another process. A companion filtered file provides the requested workflow without changing the existing raw schema or breaking playback consumers.

## Validation

- git diff --check
- all 36 Processing/JUnit tests pass under the same Processing 4.2 release used by CI
- the complete OpenBCI GUI builds successfully into 376 class files under Processing 4.2
- Python syntax check for the unit-test runner
- BrainFlow 5.22.2 prototype: 15,000 samples in 822 irregular frames, two filter epochs, bit-identical raw stream, no missing or duplicated logical sample indices, metadata round-trip, and expected synthetic-signal attenuation

The first implementation intentionally targets ODF. BDF+ can use the same epoch and sequence model after maintainers confirm the desired container behavior.

Closes #1257